### PR TITLE
Bug 1711533: auth: remove unauthenticated discovery and status access

### DIFF
--- a/pkg/authorization/apis/authorization/types.go
+++ b/pkg/authorization/apis/authorization/types.go
@@ -1,7 +1,6 @@
 package authorization
 
 import (
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -32,27 +31,6 @@ const (
 	SystemUserKind     = "SystemUser"
 	SystemGroupKind    = "SystemGroup"
 )
-
-// DiscoveryRule is a rule that allows a client to discover the API resources available on this server
-var DiscoveryRule = rbacv1.PolicyRule{
-	Verbs: []string{"get"},
-	NonResourceURLs: []string{
-		// Server version checking
-		"/version", "/version/*",
-
-		// API discovery/negotiation
-		"/api", "/api/*",
-		"/apis", "/apis/*",
-		"/oapi", "/oapi/*",
-		"/openapi/v2",
-		"/swaggerapi", "/swaggerapi/*", "/swagger.json", "/swagger-2.0.0.pb-v1",
-		"/osapi", "/osapi/", // these cannot be removed until we can drop support for pre 3.1 clients
-		"/.well-known", "/.well-known/*",
-
-		// we intentionally allow all to here
-		"/",
-	},
-}
 
 // PolicyRule holds information that describes a policy rule, but does not contain information
 // about who the rule applies to or which namespace the rule applies to.

--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -805,7 +805,7 @@ func GetOpenshiftBootstrapClusterRoleBindings() []rbacv1.ClusterRoleBinding {
 			Groups(AuthenticatedGroup, UnauthenticatedGroup).
 			BindingOrDie(),
 		newOriginClusterBinding(StatusCheckerRoleBindingName, StatusCheckerRoleName).
-			Groups(AuthenticatedGroup, UnauthenticatedGroup).
+			Groups(AuthenticatedGroup).
 			BindingOrDie(),
 		newOriginClusterBinding(NodeProxierRoleBindingName, "system:node-proxier").
 			// Allow node identities to run node proxies
@@ -819,7 +819,7 @@ func GetOpenshiftBootstrapClusterRoleBindings() []rbacv1.ClusterRoleBinding {
 			Groups(AuthenticatedGroup, UnauthenticatedGroup).
 			BindingOrDie(),
 		rbacv1helpers.NewClusterBinding(DiscoveryRoleName).
-			Groups(AuthenticatedGroup, UnauthenticatedGroup).
+			Groups(AuthenticatedGroup).
 			BindingOrDie(),
 		// Allow all build strategies by default.
 		// These are in separate bindings so that cluster admins can remove the subjects

--- a/pkg/oauth/apis/oauth/validation/validation_test.go
+++ b/pkg/oauth/apis/oauth/validation/validation_test.go
@@ -27,22 +27,22 @@ func TestValidateRedirectURI(t *testing.T) {
 
 		// With ports
 		"https://server:",
-		"https://server:port",
+		"https://server:1234",
 
 		// With or without paths, with or without trailing slashes
-		"https://server:port/",
-		"https://server:port/path-segment",
-		"https://server:port/path-segment/",
+		"https://server:1234/",
+		"https://server:1234/path-segment",
+		"https://server:1234/path-segment/",
 
 		// Things that are close to disallowed path segments
-		"https://server:port/...",
-		"https://server:port/.../",
-		"https://server:port/path-segment/...",
-		"https://server:port/path-segment/path.",
-		"https://server:port/path-segment/path./",
+		"https://server:1234/...",
+		"https://server:1234/.../",
+		"https://server:1234/path-segment/...",
+		"https://server:1234/path-segment/path.",
+		"https://server:1234/path-segment/path./",
 
 		// Double slashes
-		"https://server:port/path-segment//path",
+		"https://server:1234/path-segment//path",
 
 		// Queries
 		"http://server/path?",
@@ -64,7 +64,7 @@ func TestValidateRedirectURI(t *testing.T) {
 		"",
 
 		// invalid URL
-		"://server:port/",
+		"://server:1234/",
 
 		// . or .. segments
 		"http://server/.",

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -147,9 +147,6 @@ items:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: system:authenticated
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:unauthenticated
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -213,9 +210,6 @@ items:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: system:authenticated
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:unauthenticated
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:


### PR DESCRIPTION
This removes the actual anonynmous discovery and status access.

Follow-up of https://github.com/openshift/origin/pull/23641.