### PR TITLE
Bug 1752979: Retry imagestream imports

### DIFF
--- a/pkg/image/apiserver/importer/importer.go
+++ b/pkg/image/apiserver/importer/importer.go
@@ -2,6 +2,7 @@ package importer
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"runtime"
 	"strings"
@@ -737,6 +738,11 @@ func imageImportStatus(err error, kind, position string) metav1.Status {
 		return t.Status()
 	case *field.Error:
 		return kapierrors.NewInvalid(image.Kind(kind), position, field.ErrorList{t}).ErrStatus
+	case net.Error:
+		if t.Timeout() {
+			return kapierrors.NewTimeoutError(err.Error(), 0).ErrStatus
+		}
+		return kapierrors.NewInternalError(err).ErrStatus
 	default:
 		return kapierrors.NewInternalError(err).ErrStatus
 	}

--- a/pkg/image/apiserver/registry/imagestreamimport/rest.go
+++ b/pkg/image/apiserver/registry/imagestreamimport/rest.go
@@ -214,16 +214,32 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	// this block was introduced by PR #18012
 	// TODO: remove this blocks when smarter auth client gets done with retries
 	var imageStatus []metav1.Status
-	importFailed := false
+	authFailed := false
+	netTimeout := false
 	for _, image := range isi.Status.Images {
 		//cache all imports status
 		imageStatus = append(imageStatus, image.Status)
 		if image.Status.Reason == metav1.StatusReasonUnauthorized && strings.Contains(strings.ToLower(image.Status.Message), "username or password") {
-			importFailed = true
+			authFailed = true
+		}
+		if image.Status.Reason == metav1.StatusReasonTimeout {
+			netTimeout = true
 		}
 	}
+	// If we had a network timeout, simply retry again using same context and importFn from above
+	if netTimeout {
+		if err := imports.Import(ctx.(gocontext.Context), isi, stream); err != nil {
+			return nil, kapierrors.NewInternalError(err)
+		}
+		// re-set the "original" import status cache
+		imageStatus = []metav1.Status{}
+		for _, image := range isi.Status.Images {
+			imageStatus = append(imageStatus, image.Status)
+		}
+	}
+
 	// try import IS without auth if it failed before
-	if importFailed {
+	if authFailed {
 		importCtx := registryclient.NewContext(r.transport, r.insecureTransport).WithCredentials(nil)
 		imports := r.importFn(importCtx)
 		if err := imports.Import(ctx.(gocontext.Context), isi, stream); err != nil {


### PR DESCRIPTION
Retry an imagestream import if there is a network timeout.
Only retry once, and immediately if there is an import error.