### PR TITLE
Bug 1755115: allow scheduled imagestream imports for dockerimages with sha/digest …

### DIFF
--- a/pkg/image/apis/image/validation/validation.go
+++ b/pkg/image/apis/image/validation/validation.go
@@ -264,8 +264,6 @@ func ValidateImageStreamTagReference(
 		case "DockerImage":
 			if ref, err := imageref.Parse(tagRef.From.Name); err != nil && len(tagRef.From.Name) > 0 {
 				errs = append(errs, field.Invalid(fldPath.Child("from", "name"), tagRef.From.Name, err.Error()))
-			} else if len(ref.ID) > 0 && tagRef.ImportPolicy.Scheduled {
-				errs = append(errs, field.Invalid(fldPath.Child("from", "name"), tagRef.From.Name, "only tags can be scheduled for import"))
 			} else if whitelister != nil {
 				transport := getWhitelistTransportForFlag(tagRef.ImportPolicy.Insecure || insecureRepository, true)
 				if err := whitelister.AdmitDockerImageReference(&ref, transport); err != nil {

--- a/pkg/image/apis/image/validation/validation_test.go
+++ b/pkg/image/apis/image/validation/validation_test.go
@@ -1411,13 +1411,6 @@ func TestValidateImageStreamImport(t *testing.T) {
 						},
 						{
 							From: kapi.ObjectReference{
-								Kind: "DockerImage",
-								Name: "abc@sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25",
-							},
-							ImportPolicy: imageapi.TagImportPolicy{Scheduled: true},
-						},
-						{
-							From: kapi.ObjectReference{
 								Kind: "ImageStreamTag",
 								Name: "other:latest",
 							},
@@ -1435,9 +1428,8 @@ func TestValidateImageStreamImport(t *testing.T) {
 			},
 			expected: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "images").Index(1).Child("from", "name"), "abc@badid", "invalid reference format"),
-				field.Invalid(field.NewPath("spec", "images").Index(2).Child("from", "name"), "abc@sha256:3c87c572822935df60f0f5d3665bd376841a7fcfeb806b5f212de6a00e9a7b25", "only tags can be scheduled for import"),
-				field.Invalid(field.NewPath("spec", "images").Index(3).Child("from", "kind"), "ImageStreamTag", "only DockerImage is supported"),
-				field.Invalid(field.NewPath("spec", "images").Index(4).Child("from", "kind"), "ImageStreamImage", "only DockerImage is supported"),
+				field.Invalid(field.NewPath("spec", "images").Index(2).Child("from", "kind"), "ImageStreamTag", "only DockerImage is supported"),
+				field.Invalid(field.NewPath("spec", "images").Index(3).Child("from", "kind"), "ImageStreamImage", "only DockerImage is supported"),
 			},
 		},
 		"valid": {


### PR DESCRIPTION
…refs

per instructions from @smarterclayton  ... the api needs to be  “level driven”

with this change, we can use scheduled import to enact retry for imagestreams with dockerimage refs that container the canonical sha/digest

like the payload imagestreams oc, cli, must-gather, that reside in the openshift namespace

/assign @smarterclayton 
/assign @bparees 
/assign @dmage

@openshift/openshift-team-developer-experience FYI
@openshift/openshift-team-master FYI