### PR TITLE
[proof] TLS 1.3 does not brake openshift-apiserver

### DIFF
--- a/vendor/github.com/openshift/library-go/pkg/crypto/crypto_test.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/crypto_test.go
@@ -21,12 +21,16 @@ func TestConstantMaps(t *testing.T) {
 	}
 	discoveredVersions := map[string]bool{}
 	discoveredCiphers := map[string]bool{}
+	discoveredCiphersTLS13 := map[string]bool{}
 	for _, declName := range pkg.Scope().Names() {
 		if strings.HasPrefix(declName, "VersionTLS") {
 			discoveredVersions[declName] = true
 		}
 		if strings.HasPrefix(declName, "TLS_RSA_") || strings.HasPrefix(declName, "TLS_ECDHE_") {
 			discoveredCiphers[declName] = true
+		}
+		if strings.HasPrefix(declName, "TLS_AES_") || strings.HasPrefix(declName, "TLS_CHACHA20_") {
+			discoveredCiphersTLS13[declName] = true
 		}
 	}
 
@@ -38,6 +42,17 @@ func TestConstantMaps(t *testing.T) {
 	for k := range ciphers {
 		if _, ok := discoveredCiphers[k]; !ok {
 			t.Errorf("ciphers map has %s not in tls package", k)
+		}
+	}
+
+	for k := range discoveredCiphersTLS13 {
+		if _, ok := ciphersTLS13[k]; !ok {
+			t.Errorf("discovered cipher tls.%s not in ciphers map", k)
+		}
+	}
+	for k := range ciphersTLS13 {
+		if _, ok := discoveredCiphersTLS13[k]; !ok {
+			t.Errorf("ciphersTLS13 map has %s not in tls package", k)
 		}
 	}
 


### PR DESCRIPTION
/hold

Fake bumps library-go to see if adding 1.3 ciphers breaks the cluster or not. The ciphers should automatically be picked for the openshift-apiserver by `SetRecommendedGenericAPIServerConfigDefaults()`

openshift/library-go#553