### PR TITLE
remove side-channel wiring for cluster authentication

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
@@ -117,21 +117,10 @@ func NewOpenshiftAPIConfig(config *openshiftcontrolplanev1.OpenShiftAPIServerCon
 		return nil, err
 	}
 	authenticationOptions := genericapiserveroptions.NewDelegatingAuthenticationOptions()
-	// keep working for integration tests
-	if len(config.AggregatorConfig.ClientCA) > 0 {
-		authenticationOptions.ClientCert.ClientCA = config.ServingInfo.ClientCA
-		authenticationOptions.RequestHeader.ClientCAFile = config.AggregatorConfig.ClientCA
-		authenticationOptions.RequestHeader.AllowedNames = config.AggregatorConfig.AllowedNames
-		authenticationOptions.RequestHeader.UsernameHeaders = config.AggregatorConfig.UsernameHeaders
-		authenticationOptions.RequestHeader.GroupHeaders = config.AggregatorConfig.GroupHeaders
-		authenticationOptions.RequestHeader.ExtraHeaderPrefixes = config.AggregatorConfig.ExtraHeaderPrefixes
-	}
-	authenticationOptions.RemoteKubeConfigFile = config.KubeClientConfig.KubeConfig
 	if err := authenticationOptions.ApplyTo(&genericConfig.Authentication, genericConfig.SecureServing, genericConfig.OpenAPIConfig); err != nil {
 		return nil, err
 	}
 	authorizationOptions := genericapiserveroptions.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz", "/healthz/").WithAlwaysAllowGroups("system:masters")
-	authorizationOptions.RemoteKubeConfigFile = config.KubeClientConfig.KubeConfig
 	if err := authorizationOptions.ApplyTo(&genericConfig.Authorization); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Eventually this should wire the standard option flags through, but for now simply removing the side-channel option is enough.