### PR TITLE
WIP: Allow route subdomains to be omitted

### DIFF
--- a/pkg/route/apis/route/types.go
+++ b/pkg/route/apis/route/types.go
@@ -25,7 +25,6 @@ type RouteSpec struct {
 	// Host is an alias/DNS that points to the service. Optional
 	// Must follow DNS952 subdomain conventions.
 	Host string
-
 	// Subdomain is a DNS subdomain that is requested within the ingress controller's
 	// domain (as a subdomain). If host is set this field is ignored. An ingress
 	// controller may choose to ignore this suggested name, in which case the controller
@@ -33,13 +32,11 @@ type RouteSpec struct {
 	// route. If this value is set and the server does not support this field host will
 	// be populated automatically. Otherwise host is left empty. The field may have
 	// multiple parts separated by a dot, but not all ingress controllers may honor
-	// the request. This field may not be changed after creation except by a user with
-	// the update routes/custom-host permission.
+	// the request.
 	//
 	// Example: subdomain `frontend` automatically receives the router subdomain
 	// `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`.
 	Subdomain string
-
 	// Path that the router watches for, to route traffic for to the service. Optional
 	Path string
 

--- a/pkg/route/apis/route/v1/conversion.go
+++ b/pkg/route/apis/route/v1/conversion.go
@@ -19,6 +19,7 @@ func routeFieldSelectorKeyConversionFunc(label, value string) (internalLabel, in
 	switch label {
 	case "spec.path",
 		"spec.host",
+		"spec.subdomain",
 		"spec.to.name":
 		return label, value, nil
 	default:

--- a/pkg/route/apis/route/validation/validation.go
+++ b/pkg/route/apis/route/validation/validation.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
@@ -13,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 
 	routeapi "github.com/openshift/openshift-apiserver/pkg/route/apis/route"
@@ -27,10 +29,29 @@ func ValidateRoute(route *routeapi.Route) field.ErrorList {
 
 	specPath := field.NewPath("spec")
 
-	//host is not required but if it is set ensure it meets DNS requirements
+	//  host is not required but if it is set ensure it meets DNS requirements
 	if len(route.Spec.Host) > 0 {
+		// TODO: Add a better check that the host name matches up to
+		//       DNS requirements. Change to use:
+		//         ValidateHostName(route)
+		//       Need to check the implications of doing it here in
+		//       ValidateRoute - probably needs to be done only on
+		//       creation time for new routes.
 		if len(kvalidation.IsDNS1123Subdomain(route.Spec.Host)) != 0 {
 			result = append(result, field.Invalid(specPath.Child("host"), route.Spec.Host, "host must conform to DNS 952 subdomain conventions"))
+		}
+	}
+
+	// subdomain is not required but if it is set ensure it meets DNS requirements
+	if len(route.Spec.Subdomain) > 0 {
+		// TODO: Add a better check that the host name matches up to
+		//       DNS requirements. Change to use:
+		//         ValidateHostName(route)
+		//       Need to check the implications of doing it here in
+		//       ValidateRoute - probably needs to be done only on
+		//       creation time for new routes.
+		if len(kvalidation.IsDNS1123Subdomain(route.Spec.Subdomain)) != 0 {
+			result = append(result, field.Invalid(specPath.Child("subdomain"), route.Spec.Subdomain, "subdomain must conform to DNS 952 subdomain conventions"))
 		}
 	}
 
@@ -182,6 +203,36 @@ var knownBlockDecoders = map[string]blockVerifierFunc{
 	"EC PARAMETERS": ignoreBlockVerifier,
 }
 
+// sanitizePEM takes a block of data that should be encoded in PEM and returns only
+// the parts of it that parse and serialize as valid recognized certs in valid PEM blocks.
+// We perform this transformation to eliminate potentially incorrect / invalid PEM contents
+// to prevent OpenSSL or other non Golang tools from receiving unsanitized input.
+func sanitizePEM(data []byte) ([]byte, error) {
+	var block *pem.Block
+	buf := &bytes.Buffer{}
+	for len(data) > 0 {
+		block, data = pem.Decode(data)
+		if block == nil {
+			return buf.Bytes(), nil
+		}
+		fn, ok := knownBlockDecoders[block.Type]
+		if !ok {
+			return nil, fmt.Errorf("unrecognized PEM block %s", block.Type)
+		}
+		newBlock, err := fn(block)
+		if err != nil {
+			return nil, err
+		}
+		if newBlock == nil {
+			continue
+		}
+		if err := pem.Encode(buf, newBlock); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
 // validateTLS tests fields for different types of TLS combinations are set.  Called
 // by ValidateRoute.
 func validateTLS(route *routeapi.Route, fldPath *field.Path) field.ErrorList {
@@ -264,6 +315,37 @@ func validateInsecureEdgeTerminationPolicy(tls *routeapi.TLSConfig, fldPath *fie
 	}
 
 	return nil
+}
+
+// validateCertificatePEM checks if a certificate PEM is valid and
+// optionally verifies the certificate using the options.
+func validateCertificatePEM(certPEM string, options *x509.VerifyOptions) ([]*x509.Certificate, error) {
+	certs, err := cert.ParseCertsPEM([]byte(certPEM))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(certs) < 1 {
+		return nil, fmt.Errorf("invalid/empty certificate data")
+	}
+
+	if options != nil {
+		// Ensure we don't report errors for expired certs or if
+		// the validity is in the future.
+		// Not that this can be for the actual certificate or any
+		// intermediates in the CA chain. This allows the router to
+		// still serve an expired/valid-in-the-future certificate
+		// and lets the client to control if it can tolerate that
+		// (just like for self-signed certs).
+		_, err = certs[0].Verify(*options)
+		if err != nil {
+			if invalidErr, ok := err.(x509.CertificateInvalidError); !ok || invalidErr.Reason != x509.Expired {
+				return certs, fmt.Errorf("error verifying certificate: %s", err.Error())
+			}
+		}
+	}
+
+	return certs, nil
 }
 
 var (

--- a/pkg/route/apis/route/validation/validation_test.go
+++ b/pkg/route/apis/route/validation/validation_test.go
@@ -100,6 +100,34 @@ func TestValidateRoute(t *testing.T) {
 			expectedErrors: 1,
 		},
 		{
+			name: "Valid subdomain",
+			route: &routeapi.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routeapi.RouteSpec{
+					Subdomain: "api.ci",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid DNS 952 subdomain",
+			route: &routeapi.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routeapi.RouteSpec{
+					Subdomain: "**",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
 			name: "No service name",
 			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/route/apiserver/registry/route/strategy.go
+++ b/pkg/route/apiserver/registry/route/strategy.go
@@ -113,7 +113,7 @@ func (s routeStrategy) allocateHost(ctx context.Context, route *routeapi.Route) 
 		return nil
 	}
 
-	if len(route.Spec.Host) == 0 && s.RouteAllocator != nil {
+	if len(route.Spec.Subdomain) == 0 && len(route.Spec.Host) == 0 && s.RouteAllocator != nil {
 		// TODO: this does not belong here, and should be removed
 		shard, err := s.RouteAllocator.AllocateRouterShard(route)
 		if err != nil {
@@ -184,8 +184,9 @@ func certificateChangeRequiresAuth(route, older *routeapi.Route) bool {
 
 func (s routeStrategy) validateHostUpdate(ctx context.Context, route, older *routeapi.Route) field.ErrorList {
 	hostChanged := route.Spec.Host != older.Spec.Host
+	subdomainChanged := route.Spec.Subdomain != older.Spec.Subdomain
 	certChanged := certificateChangeRequiresAuth(route, older)
-	if !hostChanged && !certChanged {
+	if !hostChanged && !certChanged && !subdomainChanged {
 		return nil
 	}
 	user, ok := apirequest.UserFrom(ctx)
@@ -209,11 +210,17 @@ func (s routeStrategy) validateHostUpdate(ctx context.Context, route, older *rou
 		),
 	)
 	if err != nil {
+		if subdomainChanged {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "subdomain"), err)}
+		}
 		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
 	}
 	if !res.Status.Allowed {
 		if hostChanged {
 			return kvalidation.ValidateImmutableField(route.Spec.Host, older.Spec.Host, field.NewPath("spec", "host"))
+		}
+		if subdomainChanged {
+			return kvalidation.ValidateImmutableField(route.Spec.Subdomain, older.Spec.Subdomain, field.NewPath("spec", "subdomain"))
 		}
 
 		// if tls is being updated without host being updated, we check if 'create' permission exists on custom-host subresource


### PR DESCRIPTION
Following up after adding subdomain. Allows clients to request a single segment name and get allocated without having to know the subdomain up front.