### PR TITLE
Use kubeconfig file provided in configuration when specified

### DIFF
--- a/pkg/cmd/openshift-apiserver/cmd.go
+++ b/pkg/cmd/openshift-apiserver/cmd.go
@@ -123,6 +123,15 @@ func (o *OpenShiftAPIServer) RunAPIServer(stopCh <-chan struct{}) error {
 	configFileLocation := path.Dir(absoluteConfigFile)
 
 	config := obj.(*openshiftcontrolplanev1.OpenShiftAPIServerConfig)
+	// If authentication-kubeconfig or authorization-kubeconfig flag are not
+	// specified fallback to the kubeconfig file provided with the
+	// configuration.
+	if o.Authentication.RemoteKubeConfigFile == "" {
+		o.Authentication.RemoteKubeConfigFile = config.KubeClientConfig.KubeConfig
+	}
+	if o.Authorization.RemoteKubeConfigFile == "" {
+		o.Authorization.RemoteKubeConfigFile = config.KubeClientConfig.KubeConfig
+	}
 	if err := helpers.ResolvePaths(getOpenShiftAPIServerConfigFileReferences(config), configFileLocation); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is supposed to fixe the error I'm getting when running the openshift apiserver with an external `kubeConfig` file specified in the configuration [configuration](https://github.com/openshift/api/blob/master/config/v1/types.go#L268) . i.e.

```
F0401 17:48:59.903276       1 cmd.go:72] failed to get delegated authentication kubeconfig: failed to get delegated authentication kubeconfig: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory
```