### PR TITLE
Remove system:registry cluster role

### DIFF
--- a/pkg/bootstrappolicy/constants.go
+++ b/pkg/bootstrappolicy/constants.go
@@ -87,7 +87,6 @@ const (
 	ImageSignerRoleName       = "system:image-signer"
 	DeployerRoleName          = "system:deployer"
 	RouterRoleName            = "system:router"
-	RegistryRoleName          = "system:registry"
 	MasterRoleName            = "system:master"
 	SDNReaderRoleName         = "system:sdn-reader"
 	SDNManagerRoleName        = "system:sdn-manager"

--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -609,19 +609,6 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: RegistryRoleName,
-			},
-			Rules: []rbacv1.PolicyRule{
-				rbacv1helpers.NewRule("list").Groups(kapiGroup).Resources("limitranges", "resourcequotas", "imagestreams").RuleOrDie(),
-
-				rbacv1helpers.NewRule("get", "delete").Groups(imageGroup, legacyImageGroup).Resources("images", "imagestreamtags", "imagetags").RuleOrDie(),
-				rbacv1helpers.NewRule("get").Groups(imageGroup, legacyImageGroup).Resources("imagestreamimages", "imagestreams/secrets").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "update").Groups(imageGroup, legacyImageGroup).Resources("images", "imagestreams").RuleOrDie(),
-				rbacv1helpers.NewRule("create").Groups(imageGroup, legacyImageGroup).Resources("imagestreammappings").RuleOrDie(),
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
 				Name: NodeAdminRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1724,56 +1724,6 @@ items:
     annotations:
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
-    name: system:registry
-  rules:
-  - apiGroups:
-    - ""
-    resources:
-    - imagestreams
-    - limitranges
-    - resourcequotas
-    verbs:
-    - list
-  - apiGroups:
-    - ""
-    - image.openshift.io
-    resources:
-    - images
-    - imagestreamtags
-    - imagetags
-    verbs:
-    - delete
-    - get
-  - apiGroups:
-    - ""
-    - image.openshift.io
-    resources:
-    - imagestreamimages
-    - imagestreams/secrets
-    verbs:
-    - get
-  - apiGroups:
-    - ""
-    - image.openshift.io
-    resources:
-    - images
-    - imagestreams
-    verbs:
-    - get
-    - update
-  - apiGroups:
-    - ""
-    - image.openshift.io
-    resources:
-    - imagestreammappings
-    verbs:
-    - create
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      rbac.authorization.kubernetes.io/autoupdate: "true"
-    creationTimestamp: null
     name: system:node-admin
   rules:
   - apiGroups:


### PR DESCRIPTION
The system:registry cluster role in 4.x is managed by cluster-image-registry-operator

https://github.com/openshift/cluster-image-registry-operator/blob/a925d0e2ac596b393a29b808a51607a36db15f4d/pkg/resource/clusterrole.go#L44

This PR is to avoid problems when the same object is managed by two controllers.