### PR TITLE
[release-4.3] Bug 1829328: allow patch for updating namespace

### DIFF
--- a/pkg/bootstrappolicy/controller_policy.go
+++ b/pkg/bootstrappolicy/controller_policy.go
@@ -375,7 +375,7 @@ func init() {
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + InfraNamespaceSecurityAllocationControllerServiceAccountName},
 		Rules: []rbacv1.PolicyRule{
 			rbacv1helpers.NewRule("get", "create", "update").Groups(securityGroup).Resources("rangeallocations").RuleOrDie(),
-			rbacv1helpers.NewRule("get", "list", "watch", "update").Groups(kapiGroup).Resources("namespaces").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "watch", "update", "patch").Groups(kapiGroup).Resources("namespaces").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -3231,6 +3231,7 @@ items:
     verbs:
     - get
     - list
+    - patch
     - update
     - watch
   - apiGroups:


### PR DESCRIPTION
Manual cherry-pick of openshift/cluster-kube-controller-manager-operator#394 & https://github.com/openshift/openshift-apiserver/pull/100
/assign @deads2k