### PR TITLE
Bug 1841035: Add RBAC rules for volume snapshots

### DIFF
--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -60,6 +60,7 @@ var (
 	schedulingGroup            = "scheduling.k8s.io"
 	kAuthzGroup                = kauthorizationapi.GroupName
 	kAuthnGroup                = kauthenticationapi.GroupName
+	snapshotGroup              = "snapshot.storage.k8s.io"
 
 	deployGroup         = oapps.GroupName
 	authzGroup          = authorization.GroupName
@@ -342,6 +343,8 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(readWrite...).Groups(extensionsGroup, networkingGroup).Resources("networkpolicies").RuleOrDie(),
 
+				rbacv1helpers.NewRule(readWrite...).Groups(snapshotGroup).Resources("volumesnapshots").RuleOrDie(),
+
 				// backwards compatibility
 				rbacv1helpers.NewRule(readWrite...).Groups(buildGroup, legacyBuildGroup).Resources("buildlogs").RuleOrDie(),
 				rbacv1helpers.NewRule(read...).Groups(kapiGroup).Resources("resourcequotausages").RuleOrDie(),
@@ -384,6 +387,8 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(readWrite...).Groups(extensionsGroup, networkingGroup).Resources("networkpolicies").RuleOrDie(),
 
+				rbacv1helpers.NewRule(readWrite...).Groups(snapshotGroup).Resources("volumesnapshots").RuleOrDie(),
+
 				// backwards compatibility
 				rbacv1helpers.NewRule(readWrite...).Groups(buildGroup, legacyBuildGroup).Resources("buildlogs").RuleOrDie(),
 				rbacv1helpers.NewRule(read...).Groups(kapiGroup).Resources("resourcequotausages").RuleOrDie(),
@@ -417,6 +422,8 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(read...).Groups(templateGroup, legacyTemplateGroup).Resources("templates", "templateconfigs", "processedtemplates", "templateinstances").RuleOrDie(),
 
+				rbacv1helpers.NewRule(read...).Groups(snapshotGroup).Resources("volumesnapshots").RuleOrDie(),
+
 				// backwards compatibility
 				rbacv1helpers.NewRule(read...).Groups(buildGroup, legacyBuildGroup).Resources("buildlogs").RuleOrDie(),
 				rbacv1helpers.NewRule(read...).Groups(kapiGroup).Resources("resourcequotausages").RuleOrDie(),
@@ -435,6 +442,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("get", "list").Groups(authzGroup, legacyAuthzGroup).Resources("clusterroles").RuleOrDie(),
 				rbacv1helpers.NewRule(read...).Groups(rbacGroup).Resources("clusterroles").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list").Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "list").Groups(snapshotGroup).Resources("volumesnapshotclasses").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch").Groups(projectGroup, legacyProjectGroup).Resources("projects").RuleOrDie(),
 				rbacv1helpers.NewRule("create").Groups(authzGroup, legacyAuthzGroup).Resources("selfsubjectrulesreviews").RuleOrDie(),
 				rbacv1helpers.NewRule("create").Groups(kAuthzGroup).Resources("selfsubjectaccessreviews").RuleOrDie(),

--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -299,6 +299,10 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule(readWrite...).Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
 				rbacv1helpers.NewRule(read...).Groups(kapiGroup).Resources("persistentvolumeclaims", "events").RuleOrDie(),
 				rbacv1helpers.NewRule(read...).Groups(kapiGroup).Resources("pods").RuleOrDie(),
+				// VolumeSnapshotClass =~ StorageClass, VolumeSnapshotContent =~ PV
+				rbacv1helpers.NewRule(readWrite...).Groups(snapshotGroup).Resources("volumesnapshotclasses", "volumesnapshotcontents").RuleOrDie(),
+				// VolumeSnapshot =~ PVC
+				rbacv1helpers.NewRule(read...).Groups(snapshotGroup).Resources("volumesnapshots").RuleOrDie(),
 			},
 		},
 		{

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -555,6 +555,28 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - snapshot.storage.k8s.io
+    resources:
+    - volumesnapshotclasses
+    - volumesnapshotcontents
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - snapshot.storage.k8s.io
+    resources:
+    - volumesnapshots
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -821,6 +821,19 @@ items:
     - update
     - watch
   - apiGroups:
+    - snapshot.storage.k8s.io
+    resources:
+    - volumesnapshots
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
     - ""
     - build.openshift.io
     resources:
@@ -1063,6 +1076,19 @@ items:
     - update
     - watch
   - apiGroups:
+    - snapshot.storage.k8s.io
+    resources:
+    - volumesnapshots
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
     - ""
     - build.openshift.io
     resources:
@@ -1209,6 +1235,14 @@ items:
     - list
     - watch
   - apiGroups:
+    - snapshot.storage.k8s.io
+    resources:
+    - volumesnapshots
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
     - ""
     - build.openshift.io
     resources:
@@ -1270,6 +1304,13 @@ items:
     - storage.k8s.io
     resources:
     - storageclasses
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - snapshot.storage.k8s.io
+    resources:
+    - volumesnapshotclasses
     verbs:
     - get
     - list


### PR DESCRIPTION
* Allow regular users to read VolumeSnapshotClasses (similar to StorageClass)
* Allow regular users to read/write VolumeSnapshots in their namespaces (similar to PVCs)
* Allow storage-admin to read/write VolumeSnapshotClasses and VolumeSnapshotContents (~ PV) and read VolumeSnapshots (~PVCs)
