### PR TITLE
Bug 1841035: Modify basic-user and storage-admin to be aggregated

### DIFF
--- a/pkg/bootstrappolicy/all_test.go
+++ b/pkg/bootstrappolicy/all_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -16,7 +16,9 @@ const osClusterRoleAggregationPrefix = "system:openshift:"
 // this map must be manually kept up to date as we make changes to aggregation
 // we hard code this data with no constants because we cannot change the underlying values
 var expectedAggregationMap = map[string]sets.String{
+	"basic-user":     sets.NewString("system:openshift:aggregate-to-basic-user"),
 	"cluster-reader": sets.NewString("registry-viewer", "system:openshift:aggregate-to-view", "system:openshift:aggregate-to-cluster-reader"),
+	"storage-admin":  sets.NewString("system:openshift:aggregate-to-storage-admin"),
 }
 
 func TestPolicyAggregation(t *testing.T) {

--- a/pkg/bootstrappolicy/constants.go
+++ b/pkg/bootstrappolicy/constants.go
@@ -63,6 +63,8 @@ const (
 	AggregatedEditRoleName          = "system:openshift:aggregate-to-edit"
 	AggregatedViewRoleName          = "system:openshift:aggregate-to-view"
 	AggregatedClusterReaderRoleName = "system:openshift:aggregate-to-cluster-reader"
+	AggregatedBasicUserRoleName     = "system:openshift:aggregate-to-basic-user"
+	AggregatedStorageAdminRoleName  = "system:openshift:aggregate-to-storage-admin"
 	SelfProvisionerRoleName         = "self-provisioner"
 	BasicUserRoleName               = "basic-user"
 	StatusCheckerRoleName           = "cluster-status"

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -504,13 +504,27 @@ items:
     - builds/jenkinspipeline
     verbs:
     - create
-- apiVersion: rbac.authorization.k8s.io/v1
+- aggregationRule:
+    clusterRoleSelectors:
+    - matchLabels:
+        storage.openshift.io/aggregate-to-storage-admin: "true"
+  apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     annotations:
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     name: storage-admin
+  rules: null
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      storage.openshift.io/aggregate-to-storage-admin: "true"
+    name: system:openshift:aggregate-to-storage-admin
   rules:
   - apiGroups:
     - ""
@@ -1225,7 +1239,11 @@ items:
     - get
     - list
     - watch
-- apiVersion: rbac.authorization.k8s.io/v1
+- aggregationRule:
+    clusterRoleSelectors:
+    - matchLabels:
+        authorization.openshift.io/aggregate-to-basic-user: "true"
+  apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
     annotations:
@@ -1233,6 +1251,16 @@ items:
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     name: basic-user
+  rules: null
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      authorization.openshift.io/aggregate-to-basic-user: "true"
+    name: system:openshift:aggregate-to-basic-user
   rules:
   - apiGroups:
     - ""


### PR DESCRIPTION
We want to be able to add them permissions to read/write snapshots. Since volume snapshots are based on CRDs, those rules will be added in csi-snapshot-controller-operator. See https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/39
