### PR TITLE
Bug 1751258: Using manifest digest on manifest list import

### DIFF
--- a/pkg/image/apiserver/importer/importer_test.go
+++ b/pkg/image/apiserver/importer/importer_test.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/reference"
@@ -57,8 +58,10 @@ type mockRepository struct {
 
 	blobs *mockBlobStore
 
-	manifest distribution.Manifest
-	tags     map[string]string
+	manifest       distribution.Manifest
+	manifestReqs   []godigest.Digest
+	extraManifests map[godigest.Digest]distribution.Manifest
+	tags           map[string]string
 }
 
 func (r *mockRepository) Name() string { return "test" }
@@ -75,6 +78,12 @@ func (r *mockRepository) Exists(ctx context.Context, dgst godigest.Digest) (bool
 	return false, r.getErr
 }
 func (r *mockRepository) Get(ctx context.Context, dgst godigest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	r.manifestReqs = append(r.manifestReqs, dgst)
+	for d, manifest := range r.extraManifests {
+		if dgst == d {
+			return manifest, nil
+		}
+	}
 	for _, option := range options {
 		if _, ok := option.(distribution.WithTagOption); ok {
 			return r.manifest, r.getByTagErr
@@ -240,6 +249,251 @@ func expectStatusError(status metav1.Status, message string) bool {
 		return false
 	}
 	return true
+}
+
+var manifestListJSON = []byte(`
+{
+  "manifests": [
+    {
+      "digest": "sha256:cd42b54dfb86ac681ba9398a535541f6652fae2ef22f93588fe37940aedac3f4",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      },
+      "size": 1152
+    },
+    {
+      "digest": "sha256:e9c44dbc9e1b732118bddc9b13f23295750889571ab8d66dd0b07fde59dc187e",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "platform": {
+        "architecture": "arm",
+        "os": "linux",
+        "variant": "v7"
+      },
+      "size": 1152
+    },
+    {
+      "digest": "sha256:1a06d68cb9117b52965035a5b0fa4c1470ef892e6062ffedb1af1922952e0950",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux",
+        "variant": "v8"
+      },
+      "size": 1152
+    },
+    {
+      "digest": "sha256:8fc36de4b957529f5a274da741739aa47b899368318c88bb6bebf9d9e6b0ccd0",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "platform": {
+        "architecture": "386",
+        "os": "linux"
+      },
+      "size": 1152
+    },
+    {
+      "digest": "sha256:0dcd8df85597396276e73ec96deb5c67c03c09b69297f7f3eb1a278649ec8e9b",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "platform": {
+        "architecture": "ppc64le",
+        "os": "linux"
+      },
+      "size": 1152
+    },
+    {
+      "digest": "sha256:0d66f428f847be647731237ae59b41b7d9734d4b43f37c03fffde8c10bc0134a",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "platform": {
+        "architecture": "s390x",
+        "os": "linux"
+      },
+      "size": 1152
+    }
+  ],
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "schemaVersion": 2
+}
+`)
+
+var innerManifestJSON = []byte(`
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+  "config": {
+    "mediaType": "application/vnd.docker.container.image.v1+json",
+    "size": 3409,
+    "digest": "sha256:a2a15febcdf362f6115e801d37b5e60d6faaeedcb9896155e5fe9d754025be12"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 26687415,
+      "digest": "sha256:35c102085707f703de2d9eaad8752d6fe1b8f02b5d2149f1d8357c9cc7fb7d0a"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 35366,
+      "digest": "sha256:251f5509d51d9e4119d4ffb70d4820f8e2d7dc72ad15df3ebd7cd755539e40fd"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 848,
+      "digest": "sha256:8e829fe70a46e3ac4334823560e98b257234c23629f19f05460e21a453091e6d"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 162,
+      "digest": "sha256:6001e1789921cf851f6fb2e5fe05be70f482fe9c2286f66892fe5a3bc404569c"
+    }
+  ]
+}
+`)
+
+var innerImageConfigJSON = []byte(`
+{
+  "architecture": "amd64",
+  "config": {
+    "Hostname": "",
+    "Domainname": "",
+    "User": "",
+    "AttachStdin": false,
+    "AttachStdout": false,
+    "AttachStderr": false,
+    "Tty": false,
+    "OpenStdin": false,
+    "StdinOnce": false,
+    "Env": [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    ],
+    "Cmd": [
+      "/bin/bash"
+    ],
+    "ArgsEscaped": true,
+    "Image": "sha256:bcbe079849fdbb50b3eb04798547e046bdbc82020b8b780d767cf29f7e60b396",
+    "Volumes": null,
+    "WorkingDir": "",
+    "Entrypoint": null,
+    "OnBuild": null,
+    "Labels": null
+  },
+  "container": "41b694b9b42f9c5ef7fb40c24272927a727a6d6cb8120bb3eae5849ceb9bee77",
+  "container_config": {
+    "Hostname": "41b694b9b42f",
+    "Domainname": "",
+    "User": "",
+    "AttachStdin": false,
+    "AttachStdout": false,
+    "AttachStderr": false,
+    "Tty": false,
+    "OpenStdin": false,
+    "StdinOnce": false,
+    "Env": [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    ],
+    "Cmd": [
+      "/bin/sh",
+      "-c",
+      "#(nop) ",
+      "CMD [\"/bin/bash\"]"
+    ],
+    "ArgsEscaped": true,
+    "Image": "sha256:bcbe079849fdbb50b3eb04798547e046bdbc82020b8b780d767cf29f7e60b396",
+    "Volumes": null,
+    "WorkingDir": "",
+    "Entrypoint": null,
+    "OnBuild": null,
+    "Labels": {}
+  },
+  "created": "2019-08-15T07:28:14.830150536Z",
+  "docker_version": "18.06.1-ce",
+  "history": [
+    {
+      "created": "2019-08-15T07:28:12.433344678Z",
+      "created_by": "/bin/sh -c #(nop) ADD file:c477cb0e95c56b51e0b7353f3805165393689902b82a41bbe77dbef4b31667e1 in / "
+    },
+    {
+      "created": "2019-08-15T07:28:13.20852008Z",
+      "created_by": "/bin/sh -c [ -z \"$(apt-get indextargets)\" ]"
+    },
+    {
+      "created": "2019-08-15T07:28:13.964607567Z",
+      "created_by": "/bin/sh -c set -xe \t\t&& echo '#!/bin/sh' > /usr/sbin/policy-rc.d \t&& echo 'exit 101' >> /usr/sbin/policy-rc.d \t&& chmod +x /usr/sbin/policy-rc.d \t\t&& dpkg-divert --local --rename --add /sbin/initctl \t&& cp -a /usr/sbin/policy-rc.d /sbin/initctl \t&& sed -i 's/^exit.*/exit 0/' /sbin/initctl \t\t&& echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup \t\t&& echo 'DPkg::Post-Invoke { \"rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true\"; };' > /etc/apt/apt.conf.d/docker-clean \t&& echo 'APT::Update::Post-Invoke { \"rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true\"; };' >> /etc/apt/apt.conf.d/docker-clean \t&& echo 'Dir::Cache::pkgcache \"\"; Dir::Cache::srcpkgcache \"\";' >> /etc/apt/apt.conf.d/docker-clean \t\t&& echo 'Acquire::Languages \"none\";' > /etc/apt/apt.conf.d/docker-no-languages \t\t&& echo 'Acquire::GzipIndexes \"true\"; Acquire::CompressionTypes::Order:: \"gz\";' > /etc/apt/apt.conf.d/docker-gzip-indexes \t\t&& echo 'Apt::AutoRemove::SuggestsImportant \"false\";' > /etc/apt/apt.conf.d/docker-autoremove-suggests"
+    },
+    {
+      "created": "2019-08-15T07:28:14.64282638Z",
+      "created_by": "/bin/sh -c mkdir -p /run/systemd && echo 'docker' > /run/systemd/container"
+    },
+    {
+      "created": "2019-08-15T07:28:14.830150536Z",
+      "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/bash\"]",
+      "empty_layer": true
+    }
+  ],
+  "os": "linux",
+  "rootfs": {
+    "type": "layers",
+    "diff_ids": [
+      "sha256:6cebf3abed5fac58d2e792ce8461454e92c245d5312c42118f02e231a73b317f",
+      "sha256:f7eae43028b334123c3a1d778f7bdf9783bbe651c8b15371df0120fd13ec35c5",
+      "sha256:7beb13bce073c21c9ee608acb13c7e851845245dc76ce81b418fdf580c45076b",
+      "sha256:122be11ab4a29e554786b4a1ec4764dd55656b59d6228a0a3de78eaf5c1f226c"
+    ]
+  }
+}
+`)
+
+func TestImportManifestList(t *testing.T) {
+	manifestList := &manifestlist.DeserializedManifestList{}
+	if err := manifestList.UnmarshalJSON(manifestListJSON); err != nil {
+		t.Fatal(err)
+	}
+	innerManifest := &schema2.DeserializedManifest{}
+	if err := innerManifest.UnmarshalJSON(innerManifestJSON); err != nil {
+		t.Fatal(err)
+	}
+
+	mockRepo := &mockRepository{
+		manifest: manifestList,
+		blobs: &mockBlobStore{
+			blobs: map[godigest.Digest][]byte{
+				"sha256:a2a15febcdf362f6115e801d37b5e60d6faaeedcb9896155e5fe9d754025be12": innerImageConfigJSON,
+			},
+		},
+		extraManifests: map[godigest.Digest]distribution.Manifest{
+			manifestList.Manifests[0].Descriptor.Digest: innerManifest,
+		},
+	}
+	retriever := &mockRetriever{repo: mockRepo}
+
+	isi := imageapi.ImageStreamImport{
+		Spec: imageapi.ImageStreamImportSpec{
+			Images: []imageapi.ImageImportSpec{
+				{
+					From: kapi.ObjectReference{
+						Kind: "DockerImage",
+						Name: "test@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90",
+					},
+				},
+			},
+		},
+	}
+
+	im := NewImageStreamImporter(retriever, nil, 5, nil, nil)
+	if err := im.Import(nil, &isi, &imageapi.ImageStream{}); err != nil {
+		t.Errorf("importing manifest list returned: %v", err)
+	}
+
+	expectedRequests := []godigest.Digest{
+		"sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90",
+		"sha256:cd42b54dfb86ac681ba9398a535541f6652fae2ef22f93588fe37940aedac3f4",
+	}
+	if !reflect.DeepEqual(mockRepo.manifestReqs, expectedRequests) {
+		t.Errorf("expected requests diverge from requests made: %v, %v", expectedRequests, mockRepo.manifestReqs)
+	}
+	if isi.Status.Images[0].Status.Status != "Success" {
+		t.Errorf("invalid status for image import: %+v", isi.Status)
+	}
 }
 
 func TestImport(t *testing.T) {


### PR DESCRIPTION
When importing a manifest list only one manifest is imported therefore
we need to use this one manifest digest instead of the digest for the
whole manifest list when checking for integrity.