### PR TITLE
Bug 1844479: Add custom conversion for binary builds 

### DIFF
--- a/pkg/build/apis/build/v1/conversion.go
+++ b/pkg/build/apis/build/v1/conversion.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"net/url"
+
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -146,6 +148,50 @@ func Convert_build_BuildStrategy_To_v1_BuildStrategy(in *newer.BuildStrategy, ou
 		out.Type = v1.JenkinsPipelineBuildStrategyType
 	default:
 		out.Type = ""
+	}
+	return nil
+}
+
+func Convert_url_Values_To_v1_BinaryBuildRequestOptions(in *url.Values, out *v1.BinaryBuildRequestOptions, s conversion.Scope) error {
+	if in == nil || out == nil {
+		return nil
+	}
+	out.AsFile = in.Get("asFile")
+	out.Commit = in.Get("revision.commit")
+	out.Message = in.Get("revision.message")
+	out.AuthorName = in.Get("revision.authorName")
+	out.AuthorEmail = in.Get("revision.authorEmail")
+	out.CommitterName = in.Get("revision.committerName")
+	out.CommitterEmail = in.Get("revision.committerEmail")
+	return nil
+}
+
+func Convert_v1_BinaryBuildRequestOptions_To_url_Values(in *v1.BinaryBuildRequestOptions, out *url.Values, s conversion.Scope) error {
+	if in == nil || out == nil {
+		return nil
+	}
+	out.Set("asFile", in.AsFile)
+	out.Set("revision.commit", in.Commit)
+	out.Set("revision.message", in.Message)
+	out.Set("revision.authorName", in.AuthorName)
+	out.Set("revision.authorEmail", in.AuthorEmail)
+	out.Set("revision.committerName", in.CommitterName)
+	out.Set("revision.committerEmail", in.CommitterEmail)
+	return nil
+}
+
+// AddCustomConversionFuncs adds conversion functions which cannot be automatically generated.
+// This is typically due to the objects not having 1:1 field mappings.
+func AddCustomConversionFuncs(scheme *runtime.Scheme) error {
+	if err := scheme.AddConversionFunc((*url.Values)(nil), (*v1.BinaryBuildRequestOptions)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_url_Values_To_v1_BinaryBuildRequestOptions(a.(*url.Values), b.(*v1.BinaryBuildRequestOptions), scope)
+	}); err != nil {
+		return err
+	}
+	if err := scheme.AddConversionFunc((*v1.BinaryBuildRequestOptions)(nil), (*url.Values)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1_BinaryBuildRequestOptions_To_url_Values(a.(*v1.BinaryBuildRequestOptions), b.(*url.Values), scope)
+	}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/build/apis/build/v1/conversion_test.go
+++ b/pkg/build/apis/build/v1/conversion_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	kinternal "k8s.io/kubernetes/pkg/apis/core"
 
-	"github.com/openshift/api/build/v1"
+	v1 "github.com/openshift/api/build/v1"
 	"github.com/openshift/openshift-apiserver/pkg/api/apihelpers/apitesting"
 	internal "github.com/openshift/openshift-apiserver/pkg/build/apis/build"
 )
@@ -37,8 +37,13 @@ func TestFieldSelectorConversions(t *testing.T) {
 
 func TestBinaryBuildRequestOptions(t *testing.T) {
 	r := &internal.BinaryBuildRequestOptions{
-		AsFile: "Dockerfile",
-		Commit: "abcdef",
+		AsFile:         "Dockerfile",
+		Commit:         "abcdef",
+		Message:        "hello world!",
+		AuthorName:     "Jane Doe",
+		AuthorEmail:    "jdoe@email.net",
+		CommitterName:  "Bob Roberts",
+		CommitterEmail: "bobbobs@email.net",
 	}
 	versioned, err := scheme.ConvertToVersion(r, v1.GroupVersion)
 	if err != nil {
@@ -52,8 +57,26 @@ func TestBinaryBuildRequestOptions(t *testing.T) {
 	if err := scheme.Convert(&params, decoded, nil); err != nil {
 		t.Fatal(err)
 	}
-	if decoded.Commit != "abcdef" || decoded.AsFile != "Dockerfile" {
-		t.Errorf("unexpected decoded object: %#v", decoded)
+	if decoded.AsFile != r.AsFile {
+		t.Errorf("expected AsFile to be %q, got %q", r.AsFile, decoded.AsFile)
+	}
+	if decoded.Commit != r.Commit {
+		t.Errorf("expected Commit to be %q, got %q", r.Commit, decoded.Commit)
+	}
+	if decoded.Message != r.Message {
+		t.Errorf("expected Message to be %q, got %q", r.Message, decoded.Message)
+	}
+	if decoded.AuthorName != r.AuthorName {
+		t.Errorf("expected AuthorName to be %q, got %q", r.AuthorName, decoded.AuthorName)
+	}
+	if decoded.AuthorEmail != r.AuthorEmail {
+		t.Errorf("expected AuthorEmail to be %q, got %q", r.AuthorEmail, decoded.AuthorEmail)
+	}
+	if decoded.CommitterName != r.CommitterName {
+		t.Errorf("expected CommitterName to be %q, got %q", r.CommitterName, decoded.CommitterName)
+	}
+	if decoded.CommitterEmail != r.CommitterEmail {
+		t.Errorf("expected CommitterEmail to be %q, got %q", r.CommitterEmail, decoded.CommitterEmail)
 	}
 }
 

--- a/pkg/build/apis/build/v1/register.go
+++ b/pkg/build/apis/build/v1/register.go
@@ -14,6 +14,7 @@ var (
 		v1.Install,
 		corev1conversions.AddToScheme,
 		AddFieldSelectorKeyConversions,
+		AddCustomConversionFuncs,
 		RegisterDefaults,
 	)
 	Install = localSchemeBuilder.AddToScheme


### PR DESCRIPTION
Adding a manual conversion func to create BinaryBuildRequestOptions from
url query parameters. This is an attempt to address some of the issues in #95 that prevent the 1.19 rebase.

Before I go down the rabbit hole of reflection APIs, I want to make sure that this is generally the right thing to do for this situation. The test case converts url query parameters to a `BinaryBuildRequestOptions`, which exists to ensure `oc start-build` works properly.