### PR TITLE
IR-99: Adding metric for registry v1 protocol imports

### DIFF
--- a/pkg/image/apiserver/importer/importer.go
+++ b/pkg/image/apiserver/importer/importer.go
@@ -794,6 +794,7 @@ func importRepositoryFromDockerV1(ctx gocontext.Context, repository *importRepos
 	}
 
 	// load digests
+	imported := false
 	for i := range repository.Digests {
 		importDigest := &repository.Digests[i]
 		if importDigest.Err != nil || importDigest.Image != nil {
@@ -811,6 +812,7 @@ func importRepositoryFromDockerV1(ctx gocontext.Context, repository *importRepos
 			importDigest.Err = err
 			continue
 		}
+		imported = true
 	}
 
 	for i := range repository.Tags {
@@ -830,6 +832,11 @@ func importRepositoryFromDockerV1(ctx gocontext.Context, repository *importRepos
 			importTag.Err = err
 			continue
 		}
+		imported = true
+	}
+
+	if imported {
+		v1ImageImportsCounter.WithLabelValues(repository.Ref.String()).Inc()
 	}
 }
 

--- a/pkg/image/apiserver/importer/metrics.go
+++ b/pkg/image/apiserver/importer/metrics.go
@@ -1,0 +1,21 @@
+package importer
+
+import (
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	v1ImageImportsCounter = k8smetrics.NewCounterVec(
+		&k8smetrics.CounterOpts{
+			Subsystem: "apiserver",
+			Name:      "v1_image_imports_total",
+			Help:      "Counter of images imported using v1 protocol",
+		},
+		[]string{"repository"},
+	)
+)
+
+func init() {
+	legacyregistry.MustRegister(v1ImageImportsCounter)
+}


### PR DESCRIPTION
This commit adds a new metric: a counter of attempts to import images from registries using protocol v1. This protocol version has been deprecated in the past but before we remove its support from apiserver we need to be sure nobody is using it.

A PrometheusRule will be created to alert on top of this counter, as we don't have any Prometheus rule on this repository it will be created on Image Registry operator project (we already have other rules related to Image Registries in there).