### PR TITLE
Add image registry team to pkg/image OWNERS

### DIFF
--- a/pkg/image/OWNERS
+++ b/pkg/image/OWNERS
@@ -2,10 +2,11 @@ reviewers:
   - bparees
   - smarterclayton
   - soltysh
-  - miminar
   - mfojtik
   - tnozicka
   - adambkaplan
+  - dmage
+  - ricardomaraschini
 approvers:
   - bparees
   - smarterclayton
@@ -13,3 +14,4 @@ approvers:
   - mfojtik
   - tnozicka
   - adambkaplan
+  - dmage


### PR DESCRIPTION
Adding the team that owns the image API to OWNERS.