### PR TITLE
Update system:router cluster role for endpointslices

### DIFF
--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -60,6 +60,7 @@ var (
 	schedulingGroup            = "scheduling.k8s.io"
 	kAuthzGroup                = kauthorizationapi.GroupName
 	kAuthnGroup                = kauthenticationapi.GroupName
+	discoveryGroup             = "discovery.k8s.io"
 
 	deployGroup         = oapps.GroupName
 	authzGroup          = authorization.GroupName
@@ -627,6 +628,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 				Name: RouterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{
+				rbacv1helpers.NewRule("list", "watch").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch").Groups(kapiGroup).Resources("endpoints").RuleOrDie(),
 				rbacv1helpers.NewRule("list", "watch").Groups(kapiGroup).Resources("services").RuleOrDie(),
 

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1706,6 +1706,13 @@ items:
     name: system:router
   rules:
   - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs:
+    - list
+    - watch
+  - apiGroups:
     - ""
     resources:
     - endpoints


### PR DESCRIPTION
openshift-ingress (aka router) is switching to endpointslices.

Related PRs:
- https://github.com/openshift/cluster-ingress-operator/pull/426
- https://github.com/openshift/cluster-ingress-operator/pull/428
- https://github.com/openshift/router/pull/154