### PR TITLE
Bug 1820075: Delete policy for ingress-to-route-controller

### DIFF
--- a/pkg/bootstrappolicy/controller_policy.go
+++ b/pkg/bootstrappolicy/controller_policy.go
@@ -29,7 +29,6 @@ const (
 	InfraPersistentVolumeRecyclerControllerServiceAccountName   = "pv-recycler-controller"
 	InfraResourceQuotaControllerServiceAccountName              = "resourcequota-controller"
 	InfraDefaultRoleBindingsControllerServiceAccountName        = "default-rolebindings-controller"
-	InfraIngressToRouteControllerServiceAccountName             = "ingress-to-route-controller"
 
 	// template instance controller watches for TemplateInstance object creation
 	// and instantiates templates as a result.
@@ -286,18 +285,6 @@ func init() {
 		Rules: []rbacv1.PolicyRule{
 			rbacv1helpers.NewRule("list", "watch", "update").Groups(kapiGroup).Resources("services").RuleOrDie(),
 			rbacv1helpers.NewRule("update").Groups(kapiGroup).Resources("services/status").RuleOrDie(),
-			eventsRule(),
-		},
-	})
-
-	// ingress-to-route-controller
-	addControllerRole(rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + InfraIngressToRouteControllerServiceAccountName},
-		Rules: []rbacv1.PolicyRule{
-			rbacv1helpers.NewRule("get", "list", "watch").Groups(kapiGroup).Resources("secrets", "services").RuleOrDie(),
-			rbacv1helpers.NewRule("get", "list", "watch").Groups(extensionsGroup).Resources("ingress").RuleOrDie(),
-			rbacv1helpers.NewRule("get", "list", "watch", "create", "update", "patch", "delete").Groups(routeGroup).Resources("routes").RuleOrDie(),
-			rbacv1helpers.NewRule("create", "update").Groups(routeGroup).Resources("routes/custom-host").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/pkg/bootstrappolicy/dead.go
+++ b/pkg/bootstrappolicy/dead.go
@@ -74,6 +74,10 @@ func init() {
 	addDeadClusterRole("system:deploymentconfig-controller")
 	addDeadClusterRole("system:deployment-controller")
 
+	// these were moved under system:openshift:openshift-controller-manager:*
+	addDeadClusterRole("system:openshift:controller:ingress-to-route-controller")
+	addDeadClusterRoleBinding("system:openshift:controller:ingress-to-route-controller", "system:openshift:controller:ingress-to-route-controller")
+
 	// this was replaced by the node authorizer
 	addDeadClusterRoleBinding("system:nodes", "system:node")
 

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -549,21 +549,6 @@ items:
     annotations:
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
-    name: system:openshift:controller:ingress-to-route-controller
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: system:openshift:controller:ingress-to-route-controller
-  subjects:
-  - kind: ServiceAccount
-    name: ingress-to-route-controller
-    namespace: openshift-infra
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
-    annotations:
-      rbac.authorization.kubernetes.io/autoupdate: "true"
-    creationTimestamp: null
     name: system:openshift:controller:pv-recycler-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2904,58 +2904,6 @@ items:
     annotations:
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
-    name: system:openshift:controller:ingress-to-route-controller
-  rules:
-  - apiGroups:
-    - ""
-    resources:
-    - secrets
-    - services
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - extensions
-    resources:
-    - ingress
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - route.openshift.io
-    resources:
-    - routes
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - route.openshift.io
-    resources:
-    - routes/custom-host
-    verbs:
-    - create
-    - update
-  - apiGroups:
-    - ""
-    resources:
-    - events
-    verbs:
-    - create
-    - patch
-    - update
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRole
-  metadata:
-    annotations:
-      rbac.authorization.kubernetes.io/autoupdate: "true"
-    creationTimestamp: null
     name: system:openshift:controller:pv-recycler-controller
   rules:
   - apiGroups:


### PR DESCRIPTION
The cluster role and binding for the ingress-to-route controller will be managed by the openshift-controller-manager operator.

* `pkg/bootstrappolicy/controller_policy.go` (`InfraIngressToRouteControllerServiceAccountName`): Delete constant.
(`init`): Delete the `system:openshift:controller:ingress-to-route-controller` cluster role.
* `pkg/bootstrappolicy/dead.go` (`init`): Add entries for the `system:openshift:controller:ingress-to-route-controller` cluster role and cluster role binding.
* `test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml`:
* `test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml`: Regenerate.


----

See https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/169.