### PR TITLE
Bug 1884270: bypass golang url parsing with scp styled ssh git URLs; refactor URL for older git clients

### DIFF
--- a/pkg/build/apis/build/validation/s2i_validation.go
+++ b/pkg/build/apis/build/validation/s2i_validation.go
@@ -56,6 +56,8 @@ type URL struct {
 // Parse parses a "Git URL"
 func parseGitURL(rawurl string) (*URL, error) {
 	if urlSchemeRegexp.MatchString(rawurl) &&
+		// at least through golang 1.14.9, url.Parse cannot handle ssh://git@github.com:sclorg/nodejs-ex
+		!strings.HasPrefix(rawurl, "ssh://") &&
 		(runtime.GOOS != "windows" || !dosDriveRegexp.MatchString(rawurl)) {
 		u, err := url.Parse(rawurl)
 		if err != nil {
@@ -74,6 +76,12 @@ func parseGitURL(rawurl string) (*URL, error) {
 			URL:  *u,
 			Type: URLTypeURL,
 		}, nil
+	}
+
+	// if ssh://git@github.com:sclorg/nodejs-ex then strip ssh:// a la what we
+	// see in other upstream git parsing handling of scp styled git URLs;
+	if strings.HasPrefix(rawurl, "ssh://") {
+		rawurl = strings.Trim(rawurl, "ssh://")
 	}
 
 	s, fragment := splitOnByte(rawurl, '#')

--- a/pkg/build/apis/build/validation/validation_test.go
+++ b/pkg/build/apis/build/validation/validation_test.go
@@ -258,6 +258,36 @@ func TestBuildValidationFailure(t *testing.T) {
 	}
 }
 
+func TestBuildValidationWithSCPStyledURL(t *testing.T) {
+	build := &buildapi.Build{
+		ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: ""},
+		Spec: buildapi.BuildSpec{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
+						URI: "ssh://git@github.com:sclorg/nodejs-ex",
+					},
+				},
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{},
+				},
+				Output: buildapi.BuildOutput{
+					To: &kapi.ObjectReference{
+						Kind: "DockerImage",
+						Name: "repository/data",
+					},
+				},
+			},
+		},
+		Status: buildapi.BuildStatus{
+			Phase: buildapi.BuildPhaseNew,
+		},
+	}
+	if result := ValidateBuild(build); len(result) != 2 {
+		t.Errorf("Unexpected validation result: %v", result)
+	}
+}
+
 func newDefaultParameters() buildapi.BuildSpec {
 	return buildapi.BuildSpec{
 		CommonSpec: buildapi.CommonSpec{


### PR DESCRIPTION
Turns our we do not vendor in openshift/source-to-image, but copy some of its packages into openshift/openshift-apiserver

Assuming there is a rationale / history on that, and am not going to bother altering the apporach.

So I'm porting our recent fix ohttps://github.com/openshift/source-to-image/commit/129c90e36fec88dae5e2910a0de4082836e1b623

/assign @adambkaplan 