### PR TITLE
Bug 1867380: When using webhooks in OCP 4.5 fails to rollout latest deploymentconfig

### DIFF
--- a/pkg/apps/apiserver/registry/instantiate/rest.go
+++ b/pkg/apps/apiserver/registry/instantiate/rest.go
@@ -107,7 +107,7 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		config.Status.LatestVersion++
 
 		userInfo, _ := apirequest.UserFrom(ctx)
-		attrs := admission.NewAttributesRecord(config, old, apps.Kind("DeploymentConfig").WithVersion(""), config.Namespace, config.Name, apps.Resource("DeploymentConfig").WithVersion(""), "", admission.Update,
+		attrs := admission.NewAttributesRecord(config, old, apps.Kind("DeploymentConfig").WithVersion("v1"), config.Namespace, config.Name, apps.Resource("DeploymentConfig").WithVersion("v1"), "", admission.Update,
 			options, false, userInfo)
 		objectInterfaces := admission.NewObjectInterfacesFromScheme(legacyscheme.Scheme)
 		if err := s.admit.(admission.MutationInterface).Admit(ctx, attrs, objectInterfaces); err != nil {


### PR DESCRIPTION
`DeploymentConfig` kind is registered under `v1` in the scheme. Registration happens here https://github.com/openshift/openshift-apiserver/blob/e75d326783d96501e0904dfd787eca4fc08b900a/pkg/apps/apis/apps/v1/register.go#L15

When calling a webhook we need to specify the version explicitly otherwise the kind won't be found in the registry and the requests will fail with `no kind "DeploymentConfig" is registered for version "apps.openshift.io/" in scheme`


It seems this was the only place it was broken. Feel free to double-check that.