### PR TITLE
Bug 1915661: update image-pruner role to include jobs, cronjobs and statefulsets

### DIFF
--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -179,10 +179,6 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(read...).Groups(coordinationGroup).Resources("leases").RuleOrDie(),
 
-				rbacv1helpers.NewRule(read...).Groups(extensionsGroup).Resources("daemonsets/status", "deployments/status", "horizontalpodautoscalers",
-					"horizontalpodautoscalers/status", "ingresses/status", "jobs", "jobs/status", "podsecuritypolicies", "replicasets/status", "replicationcontrollers",
-					"storageclasses", "thirdpartyresources").RuleOrDie(),
-
 				rbacv1helpers.NewRule(read...).Groups(eventsGroup).Resources("events").RuleOrDie(),
 
 				rbacv1helpers.NewRule(read...).Groups(networkingGroup).Resources("ingresses/status").RuleOrDie(),
@@ -352,7 +348,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(readWrite...).Groups(templateGroup, legacyTemplateGroup).Resources("templates", "templateconfigs", "processedtemplates", "templateinstances").RuleOrDie(),
 
-				rbacv1helpers.NewRule(readWrite...).Groups(extensionsGroup, networkingGroup).Resources("networkpolicies").RuleOrDie(),
+				rbacv1helpers.NewRule(readWrite...).Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
 
 				// backwards compatibility
 				rbacv1helpers.NewRule(readWrite...).Groups(buildGroup, legacyBuildGroup).Resources("buildlogs").RuleOrDie(),
@@ -394,7 +390,7 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(readWrite...).Groups(templateGroup, legacyTemplateGroup).Resources("templates", "templateconfigs", "processedtemplates", "templateinstances").RuleOrDie(),
 
-				rbacv1helpers.NewRule(readWrite...).Groups(extensionsGroup, networkingGroup).Resources("networkpolicies").RuleOrDie(),
+				rbacv1helpers.NewRule(readWrite...).Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
 
 				// backwards compatibility
 				rbacv1helpers.NewRule(readWrite...).Groups(buildGroup, legacyBuildGroup).Resources("buildlogs").RuleOrDie(),
@@ -565,10 +561,10 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("get", "list").Groups(deployGroup, legacyDeployGroup).Resources("deploymentconfigs").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list").Groups(batchGroup).Resources("jobs").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list").Groups(batchGroup).Resources("cronjobs").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "list").Groups(appsGroup, extensionsGroup).Resources("daemonsets").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "list").Groups(appsGroup, extensionsGroup).Resources("deployments").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "list").Groups(appsGroup, extensionsGroup).Resources("replicasets").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "list").Groups(appsGroup, extensionsGroup).Resources("statefulsets").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "list").Groups(appsGroup).Resources("daemonsets").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "list").Groups(appsGroup).Resources("deployments").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "list").Groups(appsGroup).Resources("replicasets").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "list").Groups(appsGroup).Resources("statefulsets").RuleOrDie(),
 
 				rbacv1helpers.NewRule("delete").Groups(imageGroup, legacyImageGroup).Resources("images").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list", "watch").Groups(imageGroup, legacyImageGroup).Resources("images", "imagestreams").RuleOrDie(),
@@ -673,7 +669,6 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule(read...).Groups(networkGroup, legacyNetworkGroup).Resources("egressnetworkpolicies", "hostsubnets", "netnamespaces").RuleOrDie(),
 				rbacv1helpers.NewRule(read...).Groups(kapiGroup).Resources("nodes", "namespaces").RuleOrDie(),
-				rbacv1helpers.NewRule(read...).Groups(extensionsGroup).Resources("networkpolicies").RuleOrDie(),
 				rbacv1helpers.NewRule(read...).Groups(networkingGroup).Resources("networkpolicies").RuleOrDie(),
 				rbacv1helpers.NewRule("get").Groups(networkGroup, legacyNetworkGroup).Resources("clusternetworks").RuleOrDie(),
 				rbacv1helpers.NewRule("create", "update", "patch").Groups(kapiGroup).Resources("events").RuleOrDie(),

--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -563,9 +563,12 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("list").Groups(kapiGroup).Resources("limitranges").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list").Groups(buildGroup, legacyBuildGroup).Resources("buildconfigs", "builds").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list").Groups(deployGroup, legacyDeployGroup).Resources("deploymentconfigs").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "list").Groups(batchGroup).Resources("jobs").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "list").Groups(batchGroup).Resources("cronjobs").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list").Groups(appsGroup, extensionsGroup).Resources("daemonsets").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list").Groups(appsGroup, extensionsGroup).Resources("deployments").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list").Groups(appsGroup, extensionsGroup).Resources("replicasets").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "list").Groups(appsGroup, extensionsGroup).Resources("statefulsets").RuleOrDie(),
 
 				rbacv1helpers.NewRule("delete").Groups(imageGroup, legacyImageGroup).Resources("images").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list", "watch").Groups(imageGroup, legacyImageGroup).Resources("images", "imagestreams").RuleOrDie(),

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -149,25 +149,6 @@ items:
     - list
     - watch
   - apiGroups:
-    - extensions
-    resources:
-    - daemonsets/status
-    - deployments/status
-    - horizontalpodautoscalers
-    - horizontalpodautoscalers/status
-    - ingresses/status
-    - jobs
-    - jobs/status
-    - podsecuritypolicies
-    - replicasets/status
-    - replicationcontrollers
-    - storageclasses
-    - thirdpartyresources
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
     - events.k8s.io
     resources:
     - events
@@ -813,7 +794,6 @@ items:
     - update
     - watch
   - apiGroups:
-    - extensions
     - networking.k8s.io
     resources:
     - networkpolicies
@@ -1055,7 +1035,6 @@ items:
     - update
     - watch
   - apiGroups:
-    - extensions
     - networking.k8s.io
     resources:
     - networkpolicies
@@ -1534,7 +1513,6 @@ items:
     - list
   - apiGroups:
     - apps
-    - extensions
     resources:
     - daemonsets
     verbs:
@@ -1542,7 +1520,6 @@ items:
     - list
   - apiGroups:
     - apps
-    - extensions
     resources:
     - deployments
     verbs:
@@ -1550,7 +1527,6 @@ items:
     - list
   - apiGroups:
     - apps
-    - extensions
     resources:
     - replicasets
     verbs:
@@ -1558,7 +1534,6 @@ items:
     - list
   - apiGroups:
     - apps
-    - extensions
     resources:
     - statefulsets
     verbs:
@@ -1850,14 +1825,6 @@ items:
     resources:
     - namespaces
     - nodes
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - extensions
-    resources:
-    - networkpolicies
     verbs:
     - get
     - list

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1519,6 +1519,20 @@ items:
     - get
     - list
   - apiGroups:
+    - batch
+    resources:
+    - jobs
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - batch
+    resources:
+    - cronjobs
+    verbs:
+    - get
+    - list
+  - apiGroups:
     - apps
     - extensions
     resources:
@@ -1539,6 +1553,14 @@ items:
     - extensions
     resources:
     - replicasets
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - apps
+    - extensions
+    resources:
+    - statefulsets
     verbs:
     - get
     - list


### PR DESCRIPTION
The oc code which added jobs, cronjobs and statefulset is in https://github.com/openshift/oc/pull/671
/assign @sttts 