### PR TITLE
Bug 1900989: policy/unidling-controller: allow get/update on services

### DIFF
--- a/pkg/bootstrappolicy/controller_policy.go
+++ b/pkg/bootstrappolicy/controller_policy.go
@@ -269,7 +269,7 @@ func init() {
 	addControllerRole(rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + InfraUnidlingControllerServiceAccountName},
 		Rules: []rbacv1.PolicyRule{
-			rbacv1helpers.NewRule("get", "update").Groups(kapiGroup).Resources("replicationcontrollers/scale", "endpoints").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "update").Groups(kapiGroup).Resources("replicationcontrollers/scale", "endpoints", "services").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "update", "patch").Groups(kapiGroup).Resources("replicationcontrollers").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "update", "patch").Groups(deployGroup, legacyDeployGroup).Resources("deploymentconfigs").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "update").Groups(extensionsGroup, appsGroup).Resources("replicasets/scale", "deployments/scale").RuleOrDie(),

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2794,6 +2794,7 @@ items:
     resources:
     - endpoints
     - replicationcontrollers/scale
+    - services
     verbs:
     - get
     - update


### PR DESCRIPTION
oc/idle is now updating the service in addition to the endpoints when
idling.

Related PRs:

- https://github.com/openshift/openshift-controller-manager/pull/165
- https://github.com/openshift/oc/pull/720
- https://github.com/openshift/router/pull/225
- https://github.com/openshift/sdn/pull/252