### PR TITLE
REVERT: adds a custom round tripper for logging SAR requests

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
@@ -39,6 +39,7 @@ func NewOpenshiftAPIConfig(config *openshiftcontrolplanev1.OpenShiftAPIServerCon
 	if err != nil {
 		return nil, err
 	}
+
 	kubeClient, err := kubernetes.NewForConfig(kubeClientConfig)
 	if err != nil {
 		return nil, err

--- a/vendor/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/vendor/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -264,7 +264,8 @@ func (rtr *roundTripReporter) roundTripWithDelegate(req *http.Request, delegate 
 
 	grepPrefix := "cb:sar"
 
-	if rsp != nil && (rsp.StatusCode >= 400 && rsp.StatusCode < 600) {
+	if rsp != nil {
+	//if rsp != nil && (rsp.StatusCode >= 400 && rsp.StatusCode < 600) {
 		klog.Infof("%s:sc: unexpected HTTP status code %d returned, url %v", grepPrefix, rsp.StatusCode, req.URL.Path)
 	}
 


### PR DESCRIPTION
it should be removed before 4.8 release.
it is meant to help us gather data across CI runs.