### PR TITLE
Bug 1931897: scale should use autoscaling/v1 not extensions/v1beta1

### DIFF
--- a/pkg/apps/apiserver/registry/deployconfig/etcd/etcd.go
+++ b/pkg/apps/apiserver/registry/deployconfig/etcd/etcd.go
@@ -21,7 +21,6 @@ import (
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 
 	"github.com/openshift/api/apps"
-	appsapiv1 "github.com/openshift/api/apps/v1"
 	"github.com/openshift/library-go/pkg/apps/appsutil"
 	"github.com/openshift/openshift-apiserver/pkg/api/legacy"
 	appsapi "github.com/openshift/openshift-apiserver/pkg/apps/apis/apps"
@@ -95,8 +94,7 @@ func (r *ScaleREST) New() runtime.Object {
 
 func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
 	switch containingGV {
-	case appsapiv1.SchemeGroupVersion,
-		legacy.GroupVersion:
+	case legacy.GroupVersion:
 		return extensionsv1beta1.SchemeGroupVersion.WithKind("Scale")
 	default:
 		return autoscalingv1.SchemeGroupVersion.WithKind("Scale")


### PR DESCRIPTION
Scaling returns long removed endpoint:

```
$ oc scale --replicas=0 dc/test-dc
W0217 12:18:47.126349   22379 warnings.go:67] extensions/v1beta1 Scale is deprecated in v1.2+, unavailable in v1.18+
deploymentconfig.apps.openshift.io/test-dc scaled
```

if you look under the covers you'll notice it's the return value from the server:
```
I0223 16:18:04.686662   30607 request.go:1107] Response Body: {"kind":"Scale","apiVersion":"extensions/v1beta1","metadata":{"name":"testdc","namespace":"maszulik","uid":"ff872242-c285-4505-b4b0-f02384f60023","resourceVersion":"632165","creationTimestamp":"2021-02-23T11:05:05Z"},"spec":{},"status":{"replicas":0,"selector":{"deployment-config.name":"testdc","deploymentconfig":"testdc"},"targetSelector":"deployment-config.name=testdc,deploymentconfig=testdc"}}
```

/assign @deads2k 