### PR TITLE
limit basic-user cluster role well-known access to oauth-authorization-server only

### DIFF
--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -105,7 +105,7 @@ var (
 			"/openapi/v2",
 			"/swaggerapi", "/swaggerapi/*", "/swagger.json", "/swagger-2.0.0.pb-v1",
 			"/osapi", "/osapi/", // these cannot be removed until we can drop support for pre 3.1 clients
-			"/.well-known", "/.well-known/*",
+			"/.well-known", "/.well-known/oauth-authorization-server",
 
 			// we intentionally allow all to here
 			"/",

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1361,7 +1361,7 @@ items:
     - /osapi
     - /osapi/
     - /.well-known
-    - /.well-known/*
+    - /.well-known/oauth-authorization-server
     - /
     verbs:
     - get
@@ -1929,7 +1929,7 @@ items:
     - /osapi
     - /osapi/
     - /.well-known
-    - /.well-known/*
+    - /.well-known/oauth-authorization-server
     - /
     verbs:
     - get


### PR DESCRIPTION
Upstream started leveraging .well-known endpoints and only allows
serviceaccounts to access them by default. Limit
basic-user access to the `/.well-known/oauth-authorization-server`
endpoint that is needed for authentication into OpenShift.

Counter-part in kube-apiserver: https://github.com/openshift/kubernetes/pull/615

cc @deads2k @sttts 