### PR TITLE
Allow route subdomains to be omitted

### DIFF
--- a/pkg/route/apis/route/types.go
+++ b/pkg/route/apis/route/types.go
@@ -25,7 +25,6 @@ type RouteSpec struct {
 	// Host is an alias/DNS that points to the service. Optional
 	// Must follow DNS952 subdomain conventions.
 	Host string
-
 	// Subdomain is a DNS subdomain that is requested within the ingress controller's
 	// domain (as a subdomain). If host is set this field is ignored. An ingress
 	// controller may choose to ignore this suggested name, in which case the controller

--- a/pkg/route/apis/route/v1/conversion.go
+++ b/pkg/route/apis/route/v1/conversion.go
@@ -19,6 +19,7 @@ func routeFieldSelectorKeyConversionFunc(label, value string) (internalLabel, in
 	switch label {
 	case "spec.path",
 		"spec.host",
+		"spec.subdomain",
 		"spec.to.name":
 		return label, value, nil
 	default:

--- a/pkg/route/apis/route/validation/validation_test.go
+++ b/pkg/route/apis/route/validation/validation_test.go
@@ -181,6 +181,34 @@ func TestValidateRoute(t *testing.T) {
 			expectedErrors: 1,
 		},
 		{
+			name: "Valid subdomain",
+			route: &routeapi.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routeapi.RouteSpec{
+					Subdomain: "api.ci",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 0,
+		},
+		{
+			name: "Invalid DNS 952 subdomain",
+			route: &routeapi.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "foo",
+				},
+				Spec: routeapi.RouteSpec{
+					Subdomain: "**",
+					To:        createRouteSpecTo("serviceName", "Service"),
+				},
+			},
+			expectedErrors: 1,
+		},
+		{
 			name: "No service name",
 			route: &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/route/apiserver/registry/route/strategy.go
+++ b/pkg/route/apiserver/registry/route/strategy.go
@@ -116,7 +116,7 @@ func (s routeStrategy) allocateHost(ctx context.Context, route *routeapi.Route) 
 		return nil
 	}
 
-	if len(route.Spec.Host) == 0 && s.RouteAllocator != nil {
+	if len(route.Spec.Subdomain) == 0 && len(route.Spec.Host) == 0 && s.RouteAllocator != nil {
 		// TODO: this does not belong here, and should be removed
 		shard, err := s.RouteAllocator.AllocateRouterShard(route)
 		if err != nil {
@@ -187,8 +187,9 @@ func certificateChangeRequiresAuth(route, older *routeapi.Route) bool {
 
 func (s routeStrategy) validateHostUpdate(ctx context.Context, route, older *routeapi.Route) field.ErrorList {
 	hostChanged := route.Spec.Host != older.Spec.Host
+	subdomainChanged := route.Spec.Subdomain != older.Spec.Subdomain
 	certChanged := certificateChangeRequiresAuth(route, older)
-	if !hostChanged && !certChanged {
+	if !hostChanged && !certChanged && !subdomainChanged {
 		return nil
 	}
 	user, ok := apirequest.UserFrom(ctx)
@@ -214,11 +215,17 @@ func (s routeStrategy) validateHostUpdate(ctx context.Context, route, older *rou
 		metav1.CreateOptions{},
 	)
 	if err != nil {
+		if subdomainChanged {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "subdomain"), err)}
+		}
 		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
 	}
 	if !res.Status.Allowed {
 		if hostChanged {
 			return kvalidation.ValidateImmutableField(route.Spec.Host, older.Spec.Host, field.NewPath("spec", "host"))
+		}
+		if subdomainChanged {
+			return kvalidation.ValidateImmutableField(route.Spec.Subdomain, older.Spec.Subdomain, field.NewPath("spec", "subdomain"))
 		}
 
 		// if tls is being updated without host being updated, we check if 'create' permission exists on custom-host subresource

--- a/pkg/route/apiserver/registry/route/strategy_test.go
+++ b/pkg/route/apiserver/registry/route/strategy_test.go
@@ -69,6 +69,35 @@ func TestEmptyHostDefaulting(t *testing.T) {
 	}
 }
 
+func TestEmptyHostDefaultingWhenSubdomainSet(t *testing.T) {
+	ctx := apirequest.NewContext()
+	strategy := NewStrategy(testAllocator{}, &testSAR{allow: true})
+
+	hostlessCreatedRoute := &routeapi.Route{}
+	strategy.Validate(ctx, hostlessCreatedRoute)
+	if hostlessCreatedRoute.Spec.Host != "mygeneratedhost.com" {
+		t.Fatalf("Expected host to be allocated, got %s", hostlessCreatedRoute.Spec.Host)
+	}
+
+	persistedRoute := &routeapi.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "foo",
+			Name:            "myroute",
+			UID:             types.UID("abc"),
+			ResourceVersion: "1",
+		},
+		Spec: routeapi.RouteSpec{
+			Subdomain: "myhost",
+		},
+	}
+	hostlessUpdatedRoute := persistedRoute.DeepCopy()
+	hostlessUpdatedRoute.Spec.Host = ""
+	strategy.PrepareForUpdate(ctx, hostlessUpdatedRoute, persistedRoute)
+	if hostlessUpdatedRoute.Spec.Host != "" {
+		t.Fatalf("expected empty spec.host to remain unset, got %s", hostlessUpdatedRoute.Spec.Host)
+	}
+}
+
 func TestEmptyDefaultCACertificate(t *testing.T) {
 	testCases := []struct {
 		route *routeapi.Route
@@ -115,13 +144,19 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 	ctx = apirequest.WithUser(ctx, &user.DefaultInfo{Name: "bob"})
 
 	tests := []struct {
-		name           string
-		host, oldHost  string
+		name          string
+		host, oldHost string
+
+		subdomain, oldSubdomain string
+
 		wildcardPolicy routeapi.WildcardPolicyType
 		tls, oldTLS    *routeapi.TLSConfig
-		expected       string
-		errs           int
-		allow          bool
+
+		expected          string
+		expectedSubdomain string
+
+		errs  int
+		allow bool
 	}{
 		{
 			name:     "no-host-empty-policy",
@@ -220,6 +255,24 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 			wildcardPolicy: routeapi.WildcardPolicyNone,
 			allow:          true,
 			errs:           0,
+		},
+		{
+			name:              "update-changed-subdomain-denied",
+			subdomain:         "new.host",
+			expectedSubdomain: "new.host",
+			oldSubdomain:      "original.host",
+			wildcardPolicy:    routeapi.WildcardPolicyNone,
+			allow:             false,
+			errs:              1,
+		},
+		{
+			name:              "update-changed-subdomain-allowed",
+			subdomain:         "new.host",
+			expectedSubdomain: "new.host",
+			oldSubdomain:      "original.host",
+			wildcardPolicy:    routeapi.WildcardPolicyNone,
+			allow:             true,
+			errs:              0,
 		},
 		{
 			name:           "key-unchanged",
@@ -378,30 +431,11 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		sar := &testSAR{allow: tc.allow}
-		strategy := NewStrategy(testAllocator{}, sar)
+		t.Run(tc.name, func(t *testing.T) {
+			sar := &testSAR{allow: tc.allow}
+			strategy := NewStrategy(testAllocator{}, sar)
 
-		route := &routeapi.Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace:       "wildcard",
-				Name:            tc.name,
-				UID:             types.UID("wild"),
-				ResourceVersion: "1",
-			},
-			Spec: routeapi.RouteSpec{
-				Host:           tc.host,
-				WildcardPolicy: tc.wildcardPolicy,
-				TLS:            tc.tls,
-				To: routeapi.RouteTargetReference{
-					Name: "test",
-					Kind: "Service",
-				},
-			},
-		}
-
-		var errs field.ErrorList
-		if len(tc.oldHost) > 0 {
-			oldRoute := &routeapi.Route{
+			route := &routeapi.Route{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:       "wildcard",
 					Name:            tc.name,
@@ -409,26 +443,51 @@ func TestHostWithWildcardPolicies(t *testing.T) {
 					ResourceVersion: "1",
 				},
 				Spec: routeapi.RouteSpec{
-					Host:           tc.oldHost,
+					Host:           tc.host,
+					Subdomain:      tc.subdomain,
 					WildcardPolicy: tc.wildcardPolicy,
-					TLS:            tc.oldTLS,
+					TLS:            tc.tls,
 					To: routeapi.RouteTargetReference{
 						Name: "test",
 						Kind: "Service",
 					},
 				},
 			}
-			errs = strategy.ValidateUpdate(ctx, route, oldRoute)
-		} else {
-			errs = strategy.Validate(ctx, route)
-		}
 
-		if route.Spec.Host != tc.expected {
-			t.Errorf("test case %s expected host %s, got %s", tc.name, tc.expected, route.Spec.Host)
-			continue
-		}
-		if len(errs) != tc.errs {
-			t.Errorf("test case %s unexpected errors: %v %#v", tc.name, errs, sar)
-		}
+			var errs field.ErrorList
+			if len(tc.oldHost) > 0 || len(tc.oldSubdomain) > 0 || tc.oldTLS != nil {
+				oldRoute := &routeapi.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       "wildcard",
+						Name:            tc.name,
+						UID:             types.UID("wild"),
+						ResourceVersion: "1",
+					},
+					Spec: routeapi.RouteSpec{
+						Host:           tc.oldHost,
+						Subdomain:      tc.oldSubdomain,
+						WildcardPolicy: tc.wildcardPolicy,
+						TLS:            tc.oldTLS,
+						To: routeapi.RouteTargetReference{
+							Name: "test",
+							Kind: "Service",
+						},
+					},
+				}
+				errs = strategy.ValidateUpdate(ctx, route, oldRoute)
+			} else {
+				errs = strategy.Validate(ctx, route)
+			}
+
+			if route.Spec.Host != tc.expected {
+				t.Fatalf("expected host %s, got %s", tc.expected, route.Spec.Host)
+			}
+			if route.Spec.Subdomain != tc.expectedSubdomain {
+				t.Fatalf("expected subdomain %s, got %s", tc.expectedSubdomain, route.Spec.Subdomain)
+			}
+			if len(errs) != tc.errs {
+				t.Fatalf("unexpected errors: %v %#v", errs, sar)
+			}
+		})
 	}
 }


### PR DESCRIPTION
When user specifies Subdomain without Host, don't default
Host. Follow the same logic as we have for host validation
except we don't allow leniency because that is legacy code.

Mutation follows the same rules as host - must have the
appropriate permissions.