### PR TITLE
bump apiserver-lib-go for looser username validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 	github.com/openshift/api v0.0.0-20210222200543-70b287c0a0a5
-	github.com/openshift/apiserver-library-go v0.0.0-20201214145556-6f1013f42f98
+	github.com/openshift/apiserver-library-go v0.0.0-20210331084747-7da6e575a5ac
 	github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
 	github.com/openshift/client-go v0.0.0-20201214125552-e615e336eb49
 	github.com/openshift/library-go v0.0.0-20210113192829-cfbb3f4c80c2

--- a/go.sum
+++ b/go.sum
@@ -522,8 +522,8 @@ github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqi
 github.com/openshift/api v0.0.0-20201214114959-164a2fb63b5f/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
 github.com/openshift/api v0.0.0-20210222200543-70b287c0a0a5 h1:PwdrcuVguOBKjA6ZFHKzL+DnvSeF6cXkliyEJKBm7D0=
 github.com/openshift/api v0.0.0-20210222200543-70b287c0a0a5/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
-github.com/openshift/apiserver-library-go v0.0.0-20201214145556-6f1013f42f98 h1:JUz5O4PiBoEFhf/ZvwRary38hejR6E0LDEtyNro01TM=
-github.com/openshift/apiserver-library-go v0.0.0-20201214145556-6f1013f42f98/go.mod h1:bMWTKd7ZOYGyx1hVLipuA9LrIJw62V7Se99cZ/Volj8=
+github.com/openshift/apiserver-library-go v0.0.0-20210331084747-7da6e575a5ac h1:kpmbiP2FFywD777akUKSvA2iDsTY6ZUd2KMG7rlEFGQ=
+github.com/openshift/apiserver-library-go v0.0.0-20210331084747-7da6e575a5ac/go.mod h1:4MbQNvwknFf2p7p1i5B1N0Rdt4XUMl5/KgZRrXkM7DE=
 github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab h1:lBrojddP6C9C2p67EMs2vcdpC8eF+H0DDom+fgI2IF0=
 github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20201214125552-e615e336eb49 h1:7NmjUkJtGHpMTE/n8ia6itbCdZ7eYuTCXKc/zsA7OSM=
@@ -695,7 +695,6 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=

--- a/vendor/github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators/pods.go
+++ b/vendor/github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/imagereferencemutators/pods.go
@@ -8,7 +8,6 @@ import (
 	kappsv1beta2 "k8s.io/api/apps/v1beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
-	batchv2alpha1 "k8s.io/api/batch/v2alpha1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -96,13 +95,9 @@ func GetPodSpecV1(obj runtime.Object) (*corev1.PodSpec, *field.Path, error) {
 	case *batchv1.Job:
 		return &r.Spec.Template.Spec, field.NewPath("spec", "template", "spec"), nil
 
-	case *batchv2alpha1.CronJob:
-		return &r.Spec.JobTemplate.Spec.Template.Spec, field.NewPath("spec", "jobTemplate", "spec", "template", "spec"), nil
 	case *batchv1beta1.CronJob:
 		return &r.Spec.JobTemplate.Spec.Template.Spec, field.NewPath("spec", "jobTemplate", "spec", "template", "spec"), nil
 
-	case *batchv2alpha1.JobTemplate:
-		return &r.Template.Spec.Template.Spec, field.NewPath("template", "spec", "template", "spec"), nil
 	case *batchv1beta1.JobTemplate:
 		return &r.Template.Spec.Template.Spec, field.NewPath("template", "spec", "template", "spec"), nil
 
@@ -155,13 +150,9 @@ func GetTemplateMetaObject(obj runtime.Object) (metav1.Object, bool) {
 	case *batchv1.Job:
 		return &r.Spec.Template.ObjectMeta, true
 
-	case *batchv2alpha1.CronJob:
-		return &r.Spec.JobTemplate.Spec.Template.ObjectMeta, true
 	case *batchv1beta1.CronJob:
 		return &r.Spec.JobTemplate.Spec.Template.ObjectMeta, true
 
-	case *batchv2alpha1.JobTemplate:
-		return &r.Template.Spec.Template.ObjectMeta, true
 	case *batchv1beta1.JobTemplate:
 		return &r.Template.Spec.Template.ObjectMeta, true
 

--- a/vendor/github.com/openshift/apiserver-library-go/pkg/apivalidation/uservalidation.go
+++ b/vendor/github.com/openshift/apiserver-library-go/pkg/apivalidation/uservalidation.go
@@ -11,8 +11,8 @@ func ValidateUserName(name string, _ bool) []string {
 		return reasons
 	}
 
-	if strings.Contains(name, ":") {
-		return []string{`may not contain ":"`}
+	if strings.Contains(name, ":") && !strings.HasPrefix(name, "b64:") {
+		return []string{`usernames that contain ":" must begin with "b64:"`}
 	}
 	if name == "~" {
 		return []string{`may not equal "~"`}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -280,7 +280,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/apiserver-library-go v0.0.0-20201214145556-6f1013f42f98
+# github.com/openshift/apiserver-library-go v0.0.0-20210331084747-7da6e575a5ac
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/apis/imagepolicy/v1
 github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy/apis/imagepolicy/validation


### PR DESCRIPTION
Allows to include ':' in usernames if prepended by 'b64'.
This is to allow creating identities/users whose IdP-side
identifier contains either ':' or '/'. These are base64-encoded
and the result is appended after the 'b64:' tag in the object
name.

cc @sttts @deads2k