### PR TITLE
sets shutdown-delay-duration from OpenShiftAPIServerConfig

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
@@ -104,6 +104,18 @@ func NewOpenshiftAPIConfig(config *openshiftcontrolplanev1.OpenShiftAPIServerCon
 	genericConfig.MaxMutatingRequestsInFlight = int(config.ServingInfo.MaxRequestsInFlight / 2)
 	genericConfig.LongRunningFunc = apiserverconfig.IsLongRunningRequest
 
+	// It is not worse than it was before. This code deserves refactoring.
+	// Instead of having a dedicated configuration file, we should pass flags directly.
+	// Until then it seems okay to have the following construct.
+	if shutdownDelaySlice := config.APIServerArguments["shutdown-delay-duration"]; len(shutdownDelaySlice) == 1 {
+		shutdownDelay, err := time.ParseDuration(shutdownDelaySlice[0])
+		if err != nil {
+			return nil, err
+		}
+
+		genericConfig.ShutdownDelayDuration = shutdownDelay
+	}
+
 	// I'm just hoping this works.  I don't think we use it.
 	//MergedResourceConfig *serverstore.ResourceConfig
 


### PR DESCRIPTION
ShutdownDelayDuration allows to block shutdown for some time, e.g. until endpoints pointing to this API server
have converged on all node. During this time, the API server keeps serving, /healthz will return 200, but /readyz will return failure. This is important for the graceful shutdown.

