### PR TITLE
DO NOT MERGE: prove qps location

### DIFF
--- a/vendor/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/vendor/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -419,7 +419,7 @@ func (s *DelegatingAuthenticationOptions) getClient() (kubernetes.Interface, err
 	// set high qps/burst limits since this will effectively limit API server responsiveness
 	clientConfig.QPS = 200
 	clientConfig.Burst = 400
-	clientConfig.Timeout = s.ClientTimeout
+	clientConfig.Timeout = 13*time.Minute
 
 	return kubernetes.NewForConfig(clientConfig)
 }

--- a/vendor/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/vendor/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -211,7 +211,7 @@ func NewDelegatingAuthenticationOptions() *DelegatingAuthenticationOptions {
 			ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 		},
 		WebhookRetryBackoff: DefaultAuthWebhookRetryBackoff(),
-		ClientTimeout:       10 * time.Second,
+		ClientTimeout:       10 * time.Minute,
 	}
 }
 
@@ -222,7 +222,7 @@ func (s *DelegatingAuthenticationOptions) WithCustomRetryBackoff(backoff wait.Ba
 
 // WithClientTimeout sets the given timeout for the authentication webhook client.
 func (s *DelegatingAuthenticationOptions) WithClientTimeout(timeout time.Duration) {
-	s.ClientTimeout = timeout
+	s.ClientTimeout =  10 * time.Minute
 }
 
 func (s *DelegatingAuthenticationOptions) Validate() []error {

--- a/vendor/k8s.io/client-go/rest/config.go
+++ b/vendor/k8s.io/client-go/rest/config.go
@@ -324,8 +324,8 @@ func RESTClientFor(config *Config) (*RESTClient, error) {
 	var httpClient *http.Client
 	if transport != http.DefaultTransport {
 		httpClient = &http.Client{Transport: transport}
-		if config.Timeout > 0 {
-			httpClient.Timeout = config.Timeout
+		if config.Timeout > 0  && config.Timeout < 14*time.Second{
+			httpClient.Timeout = 11*time.Minute
 		}
 	}
 
@@ -383,7 +383,7 @@ func UnversionedRESTClientFor(config *Config) (*RESTClient, error) {
 	if transport != http.DefaultTransport {
 		httpClient = &http.Client{Transport: transport}
 		if config.Timeout > 0 {
-			httpClient.Timeout = config.Timeout
+			httpClient.Timeout =  14*time.Minute
 		}
 	}
 

--- a/vendor/k8s.io/client-go/tools/cache/reflector.go
+++ b/vendor/k8s.io/client-go/tools/cache/reflector.go
@@ -524,7 +524,7 @@ loop:
 	}
 
 	watchDuration := r.clock.Since(start)
-	if watchDuration < 1*time.Second && eventCount == 0 {
+	if watchDuration < 11*time.Second && eventCount == 0 {
 		return fmt.Errorf("very short watch: %s: Unexpected watch close - watch lasted less than a second and no items received", r.name)
 	}
 	klog.V(4).Infof("%s: Watch close - %v total %v items received", r.name, r.expectedTypeName, eventCount)


### PR DESCRIPTION
see if this reduces the watch qps stress we're observing. 

Look in something like `./kubectl-dev_tool audit -f 'expanded-audit-logs-dir' --user=system:serviceaccount:openshift-apiserver:openshift-apiserver-sa --by=verb -otop`

After https://github.com/openshift/cluster-debug-tools/pull/21 and https://github.com/openshift/cluster-debug-tools/pull/20