### PR TITLE
WIP: BUILD-159:fake openshift/api bump

### DIFF
--- a/vendor/github.com/openshift/api/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -45,6 +45,7 @@ spec:
                 - manila.csi.openstack.org
                 - csi.ovirt.org
                 - csi.kubevirt.io
+                - csi.projected.shared.resources.openshift.io
                 type: string
             type: object
           spec:

--- a/vendor/github.com/openshift/api/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
+++ b/vendor/github.com/openshift/api/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
@@ -12,3 +12,4 @@
       - manila.csi.openstack.org
       - csi.ovirt.org
       - csi.kubevirt.io
+      - csi.projected.shared.resources.openshift.io

--- a/vendor/github.com/openshift/api/operator/v1/types_csi_cluster_driver.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_csi_cluster_driver.go
@@ -40,14 +40,15 @@ type CSIDriverName string
 // If you are adding a new driver name here, ensure that kubebuilder:validation:Enum is updated above
 // and 0000_90_cluster_csi_driver_01_config.crd.yaml-merge-patch file is also updated with new driver name.
 const (
-	AWSEBSCSIDriver    CSIDriverName = "ebs.csi.aws.com"
-	AzureDiskCSIDriver CSIDriverName = "disk.csi.azure.com"
-	GCPPDCSIDriver     CSIDriverName = "pd.csi.storage.gke.io"
-	CinderCSIDriver    CSIDriverName = "cinder.csi.openstack.org"
-	VSphereCSIDriver   CSIDriverName = "csi.vsphere.vmware.com"
-	ManilaCSIDriver    CSIDriverName = "manila.csi.openstack.org"
-	OvirtCSIDriver     CSIDriverName = "csi.ovirt.org"
-	KubevirtCSIDriver  CSIDriverName = "csi.kubevirt.io"
+	AWSEBSCSIDriver                  CSIDriverName = "ebs.csi.aws.com"
+	AzureDiskCSIDriver               CSIDriverName = "disk.csi.azure.com"
+	GCPPDCSIDriver                   CSIDriverName = "pd.csi.storage.gke.io"
+	CinderCSIDriver                  CSIDriverName = "cinder.csi.openstack.org"
+	VSphereCSIDriver                 CSIDriverName = "csi.vsphere.vmware.com"
+	ManilaCSIDriver                  CSIDriverName = "manila.csi.openstack.org"
+	OvirtCSIDriver                   CSIDriverName = "csi.ovirt.org"
+	KubevirtCSIDriver                CSIDriverName = "csi.kubevirt.io"
+	ProjectedSharedResourceCSIDriver CSIDriverName = "csi.projected.shared.resources.openshift.io"
 )
 
 // ClusterCSIDriverSpec is the desired behavior of CSI driver operator


### PR DESCRIPTION
Before https://github.com/openshift/api/pull/952 merges, testing out these changes via clusterbot where in theory the k8s apimachinery validation producing the error:

```
The ClusterCSIDriver "csi.projected.shared.resources.openshift.io" is invalid: metadata.name: Unsupported value: "csi-driver-projected-resource.openshift.io": supported values: "ebs.csi.aws.com", "disk.csi.azure.com", "pd.csi.storage.gke.io", "cinder.csi.openstack.org", "csi.vsphere.vmware.com", "manila.csi.openstack.org", "csi.ovirt.org", "csi.kubevirt.io"
```

even with both CVO and CSO disabled per https://github.com/openshift/gcp-pd-csi-driver-operator#quick-start so that I can try running our new csi driver operator locally.