### PR TITLE
Bug 1970805: Allow forward slashes in image name

### DIFF
--- a/pkg/image/apis/image/validation/validation.go
+++ b/pkg/image/apis/image/validation/validation.go
@@ -31,7 +31,7 @@ import (
 // start with at least one letter or number, with following parts able to
 // be separated by one period, dash or underscore.
 // Copied from github.com/docker/distribution/registry/api/v2/names.go v2.1.1
-var RepositoryNameComponentRegexp = regexp.MustCompile(`[a-z0-9]+(?:[._-][a-z0-9]+)*`)
+var RepositoryNameComponentRegexp = regexp.MustCompile(`[a-z0-9\/]+(?:[._-][a-z0-9\/]+)*`)
 
 // RepositoryNameComponentAnchoredRegexp is the version of
 // RepositoryNameComponentRegexp which must completely match the content
@@ -44,8 +44,8 @@ var RepositoryNameComponentAnchoredRegexp = regexp.MustCompile(`^` + RepositoryN
 var RepositoryNameRegexp = regexp.MustCompile(`(?:` + RepositoryNameComponentRegexp.String() + `/)*` + RepositoryNameComponentRegexp.String())
 
 func ValidateImageStreamName(name string, prefix bool) []string {
-	if reasons := path.ValidatePathSegmentName(name, prefix); len(reasons) != 0 {
-		return reasons
+	if !RepositoryNameRegexp.MatchString(name) {
+		return []string{fmt.Sprintf("must match %q", RepositoryNameRegexp.String())}
 	}
 
 	if !RepositoryNameComponentAnchoredRegexp.MatchString(name) {

--- a/pkg/image/apis/image/validation/validation_test.go
+++ b/pkg/image/apis/image/validation/validation_test.go
@@ -382,25 +382,23 @@ func TestValidateImageStream(t *testing.T) {
 			name:      "",
 			expected:  field.ErrorList{missingNameErr},
 		},
-		"no slash in Name": {
+		"allow slash in Name": {
 			namespace: "foo",
 			name:      "foo/bar",
-			expected: field.ErrorList{
-				field.Invalid(field.NewPath("metadata", "name"), "foo/bar", `may not contain '/'`),
-			},
+			expected:  field.ErrorList{},
 		},
 		"no percent in Name": {
 			namespace: "foo",
 			name:      "foo%%bar",
 			expected: field.ErrorList{
-				field.Invalid(field.NewPath("metadata", "name"), "foo%%bar", `may not contain '%'`),
+				field.Invalid(field.NewPath("metadata", "name"), "foo%%bar", `must match "[a-z0-9\\/]+(?:[._-][a-z0-9\\/]+)*"`),
 			},
 		},
 		"other invalid name": {
 			namespace: "foo",
 			name:      "foo bar",
 			expected: field.ErrorList{
-				field.Invalid(field.NewPath("metadata", "name"), "foo bar", `must match "[a-z0-9]+(?:[._-][a-z0-9]+)*"`),
+				field.Invalid(field.NewPath("metadata", "name"), "foo bar", `must match "[a-z0-9\\/]+(?:[._-][a-z0-9\\/]+)*"`),
 			},
 		},
 		"missing namespace": {


### PR DESCRIPTION
BuildConfigs should allow forward slashes `/` in the docker image name

https://bugzilla.redhat.com/show_bug.cgi?id=1970805