### PR TITLE
Bug 1978627: Validate secret name and configMap name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /openshift-apiserver
+/_output

--- a/pkg/build/apis/build/validation/validation.go
+++ b/pkg/build/apis/build/validation/validation.go
@@ -810,9 +810,23 @@ func validateBuildVolume(volume buildapi.BuildVolume, fldPath *field.Path) field
 	var foundVolumeSources []string
 
 	if volume.Source.Secret != nil {
+		if len(volume.Source.Secret.SecretName) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("source").Child("secret").Child("secretName"), ""))
+		} else if reasons := validation.ValidateSecretName(volume.Source.Secret.SecretName, false); len(reasons) != 0 {
+			for _, r := range reasons {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("source").Child("secret").Child("secretName"), volume.Source.Secret, r))
+			}
+		}
 		foundVolumeSources = append(foundVolumeSources, string(buildapi.BuildVolumeSourceTypeSecret))
 	}
 	if volume.Source.ConfigMap != nil {
+		if len(volume.Source.ConfigMap.Name) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("source").Child("configMap").Child("name"), ""))
+		} else if reasons := validation.ValidateConfigMapName(volume.Source.ConfigMap.Name, false); len(reasons) != 0 {
+			for _, r := range reasons {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("source").Child("configMap").Child("name"), volume.Source.ConfigMap, r))
+			}
+		}
 		foundVolumeSources = append(foundVolumeSources, string(buildapi.BuildVolumeSourceTypeConfigMap))
 	}
 	if len(foundVolumeSources) == 0 {

--- a/pkg/build/apis/build/validation/validation_test.go
+++ b/pkg/build/apis/build/validation/validation_test.go
@@ -3389,8 +3389,10 @@ func TestValidateBuildVolumes(t *testing.T) {
 			volume: buildapi.BuildVolume{
 				Name: "",
 				Source: buildapi.BuildVolumeSource{
-					Type:   buildapi.BuildVolumeSourceTypeSecret,
-					Secret: &kapi.SecretVolumeSource{},
+					Type: buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret",
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{
 					{
@@ -3407,8 +3409,10 @@ func TestValidateBuildVolumes(t *testing.T) {
 			volume: buildapi.BuildVolume{
 				Name: "MyBuildVolume",
 				Source: buildapi.BuildVolumeSource{
-					Type:   buildapi.BuildVolumeSourceTypeSecret,
-					Secret: &kapi.SecretVolumeSource{},
+					Type: buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret",
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{
 					{
@@ -3425,8 +3429,10 @@ func TestValidateBuildVolumes(t *testing.T) {
 			volume: buildapi.BuildVolume{
 				Name: "this-volume-name-is-way-too-long-and-should-cause-an-error-since-it-is-longer-than-63-characters-long",
 				Source: buildapi.BuildVolumeSource{
-					Type:   buildapi.BuildVolumeSourceTypeSecret,
-					Secret: &kapi.SecretVolumeSource{},
+					Type: buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret",
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{
 					{
@@ -3443,7 +3449,9 @@ func TestValidateBuildVolumes(t *testing.T) {
 			volume: buildapi.BuildVolume{
 				Name: "some-volume",
 				Source: buildapi.BuildVolumeSource{
-					Secret: &kapi.SecretVolumeSource{},
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret",
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{
 					{
@@ -3491,9 +3499,15 @@ func TestValidateBuildVolumes(t *testing.T) {
 			volume: buildapi.BuildVolume{
 				Name: "some-volume",
 				Source: buildapi.BuildVolumeSource{
-					Type:      buildapi.BuildVolumeSourceTypeConfigMap,
-					Secret:    &kapi.SecretVolumeSource{},
-					ConfigMap: &kapi.ConfigMapVolumeSource{},
+					Type: buildapi.BuildVolumeSourceTypeConfigMap,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret",
+					},
+					ConfigMap: &kapi.ConfigMapVolumeSource{
+						LocalObjectReference: kapi.LocalObjectReference{
+							Name: "my-configmap",
+						},
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{
 					{
@@ -3511,8 +3525,10 @@ func TestValidateBuildVolumes(t *testing.T) {
 			volume: buildapi.BuildVolume{
 				Name: "some-volume",
 				Source: buildapi.BuildVolumeSource{
-					Type:   buildapi.BuildVolumeSourceTypeSecret,
-					Secret: &kapi.SecretVolumeSource{},
+					Type: buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret",
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{},
 			},
@@ -3523,8 +3539,10 @@ func TestValidateBuildVolumes(t *testing.T) {
 			volume: buildapi.BuildVolume{
 				Name: "some-volume",
 				Source: buildapi.BuildVolumeSource{
-					Type:   buildapi.BuildVolumeSourceTypeSecret,
-					Secret: &kapi.SecretVolumeSource{},
+					Type: buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret",
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{
 					{
@@ -3541,8 +3559,10 @@ func TestValidateBuildVolumes(t *testing.T) {
 			volume: buildapi.BuildVolume{
 				Name: "some-volume",
 				Source: buildapi.BuildVolumeSource{
-					Type:   buildapi.BuildVolumeSourceTypeSecret,
-					Secret: &kapi.SecretVolumeSource{},
+					Type: buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret",
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{
 					{
@@ -3557,8 +3577,10 @@ func TestValidateBuildVolumes(t *testing.T) {
 			volume: buildapi.BuildVolume{
 				Name: "some-volume",
 				Source: buildapi.BuildVolumeSource{
-					Type:   buildapi.BuildVolumeSourceTypeSecret,
-					Secret: &kapi.SecretVolumeSource{},
+					Type: buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret",
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{
 					{
@@ -3576,8 +3598,10 @@ func TestValidateBuildVolumes(t *testing.T) {
 			volume: buildapi.BuildVolume{
 				Name: "some-volume",
 				Source: buildapi.BuildVolumeSource{
-					Type:   buildapi.BuildVolumeSourceTypeSecret,
-					Secret: &kapi.SecretVolumeSource{},
+					Type: buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret",
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{
 					{
@@ -3588,12 +3612,122 @@ func TestValidateBuildVolumes(t *testing.T) {
 			errors: []string{"must not contain ':'"},
 		},
 		{
+			name: "secret name too long should fail",
+			volume: buildapi.BuildVolume{
+				Name: "some-volume",
+				Source: buildapi.BuildVolumeSource{
+					Type: buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "testsourceddssssssssaffffffffffffffffffffdagagddagagerqgeqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtestsourceddssssssssaffffffffffffffffffffdagagddagagerqgeqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtestsourceddssssssssaffffffffffffffffffffdagagddagagerqgeqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+					},
+				},
+				Mounts: []buildapi.BuildVolumeMount{
+					{
+						DestinationPath: "/some/path",
+					},
+				},
+			},
+			errors: []string{"must be no more than 253 characters"},
+		},
+		{
+			name: "secret name invalid characters should fail",
+			volume: buildapi.BuildVolume{
+				Name: "some-volume",
+				Source: buildapi.BuildVolumeSource{
+					Type: buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret-@",
+					},
+				},
+				Mounts: []buildapi.BuildVolumeMount{
+					{
+						DestinationPath: "/some/path",
+					},
+				},
+			},
+			errors: []string{"a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters"},
+		},
+		{
+			name: "empty secret name should fail",
+			volume: buildapi.BuildVolume{
+				Name: "some-volume",
+				Source: buildapi.BuildVolumeSource{
+					Type:   buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{},
+				},
+				Mounts: []buildapi.BuildVolumeMount{
+					{
+						DestinationPath: "/some/path",
+					},
+				},
+			},
+			errors: []string{"Required value"},
+		},
+		{
+			name: "configmap name too long should fail",
+			volume: buildapi.BuildVolume{
+				Name: "some-volume",
+				Source: buildapi.BuildVolumeSource{
+					Type: buildapi.BuildVolumeSourceTypeConfigMap,
+					ConfigMap: &kapi.ConfigMapVolumeSource{
+						LocalObjectReference: kapi.LocalObjectReference{
+							Name: "testsourceddssssssssaffffffffffffffffffffdagagddagagerqgeqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtestsourceddssssssssaffffffffffffffffffffdagagddagagerqgeqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqtestsourceddssssssssaffffffffffffffffffffdagagddagagerqgeqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+						},
+					},
+				},
+				Mounts: []buildapi.BuildVolumeMount{
+					{
+						DestinationPath: "/some/path",
+					},
+				},
+			},
+			errors: []string{"must be no more than 253 characters"},
+		},
+		{
+			name: "configMap name invalid characters should fail",
+			volume: buildapi.BuildVolume{
+				Name: "some-volume",
+				Source: buildapi.BuildVolumeSource{
+					Type: buildapi.BuildVolumeSourceTypeConfigMap,
+					ConfigMap: &kapi.ConfigMapVolumeSource{
+						LocalObjectReference: kapi.LocalObjectReference{
+							Name: "my-secret-@",
+						},
+					},
+				},
+				Mounts: []buildapi.BuildVolumeMount{
+					{
+						DestinationPath: "/some/path",
+					},
+				},
+			},
+			errors: []string{"a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters"},
+		},
+		{
+			name: "empty configMap name should fail",
+			volume: buildapi.BuildVolume{
+				Name: "some-volume",
+				Source: buildapi.BuildVolumeSource{
+					Type:      buildapi.BuildVolumeSourceTypeConfigMap,
+					ConfigMap: &kapi.ConfigMapVolumeSource{},
+				},
+				Mounts: []buildapi.BuildVolumeMount{
+					{
+						DestinationPath: "/some/path",
+					},
+				},
+			},
+			errors: []string{"Required value"},
+		},
+		{
 			name: "compliant secret volume should pass",
 			volume: buildapi.BuildVolume{
 				Name: "this-name-should-pass",
 				Source: buildapi.BuildVolumeSource{
-					Type:   buildapi.BuildVolumeSourceTypeSecret,
-					Secret: &kapi.SecretVolumeSource{},
+					Type: buildapi.BuildVolumeSourceTypeSecret,
+					Secret: &kapi.SecretVolumeSource{
+						SecretName: "my-secret",
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{
 					{
@@ -3608,8 +3742,12 @@ func TestValidateBuildVolumes(t *testing.T) {
 			volume: buildapi.BuildVolume{
 				Name: "this-name-should-pass",
 				Source: buildapi.BuildVolumeSource{
-					Type:      buildapi.BuildVolumeSourceTypeConfigMap,
-					ConfigMap: &kapi.ConfigMapVolumeSource{},
+					Type: buildapi.BuildVolumeSourceTypeConfigMap,
+					ConfigMap: &kapi.ConfigMapVolumeSource{
+						LocalObjectReference: kapi.LocalObjectReference{
+							Name: "my-configmap",
+						},
+					},
 				},
 				Mounts: []buildapi.BuildVolumeMount{
 					{
@@ -3625,7 +3763,7 @@ func TestValidateBuildVolumes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			errs := validateBuildVolume(tt.volume, field.NewPath(""))
 			if len(tt.errors) != len(errs) {
-				t.Errorf("wanted and actual errors do not match, wanted: %v, got: %v", tt.errors, errs)
+				t.Errorf("wanted and actual errors do not match, wanted %d errors: %#v, got %d errors: %v", len(tt.errors), tt.errors, len(errs), errs)
 			}
 			for _, wantError := range tt.errors {
 				foundError := false
@@ -3635,7 +3773,7 @@ func TestValidateBuildVolumes(t *testing.T) {
 					}
 				}
 				if !foundError {
-					t.Errorf("did not produce expected error, wanted: %q got: %q", wantError, errs)
+					t.Errorf("did not produce expected error, wanted: %#v got: %v", wantError, errs)
 				}
 			}
 		})


### PR DESCRIPTION
Validate the secret name and configMap name to provide a better user
experience when creating a build config that contains buildVolumes

Also, updating .gitignore to ignore _output directory that is not
cleaned up after running make verify