### PR TITLE
Bug 1971332: revert incorrect ssh scp fix

### DIFF
--- a/pkg/build/apis/build/validation/s2i_validation.go
+++ b/pkg/build/apis/build/validation/s2i_validation.go
@@ -56,8 +56,6 @@ type URL struct {
 // Parse parses a "Git URL"
 func parseGitURL(rawurl string) (*URL, error) {
 	if urlSchemeRegexp.MatchString(rawurl) &&
-		// at least through golang 1.14.9, url.Parse cannot handle ssh://git@github.com:sclorg/nodejs-ex
-		!strings.HasPrefix(rawurl, "ssh://") &&
 		(runtime.GOOS != "windows" || !dosDriveRegexp.MatchString(rawurl)) {
 		u, err := url.Parse(rawurl)
 		if err != nil {
@@ -76,12 +74,6 @@ func parseGitURL(rawurl string) (*URL, error) {
 			URL:  *u,
 			Type: URLTypeURL,
 		}, nil
-	}
-
-	// if ssh://git@github.com:sclorg/nodejs-ex then strip ssh:// a la what we
-	// see in other upstream git parsing handling of scp styled git URLs;
-	if strings.HasPrefix(rawurl, "ssh://") {
-		rawurl = strings.Trim(rawurl, "ssh://")
 	}
 
 	s, fragment := splitOnByte(rawurl, '#')

--- a/pkg/build/apis/build/validation/validation_test.go
+++ b/pkg/build/apis/build/validation/validation_test.go
@@ -258,7 +258,7 @@ func TestBuildValidationFailure(t *testing.T) {
 	}
 }
 
-func TestBuildValidationWithSCPStyledURL(t *testing.T) {
+func TestBuildValidationWithSSHSCPStyledURL(t *testing.T) {
 	build := &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: ""},
 		Spec: buildapi.BuildSpec{
@@ -283,8 +283,82 @@ func TestBuildValidationWithSCPStyledURL(t *testing.T) {
 			Phase: buildapi.BuildPhaseNew,
 		},
 	}
-	if result := ValidateBuild(build); len(result) != 2 {
-		t.Errorf("Unexpected validation result: %v", result)
+	result := ValidateBuild(build)
+	foundError := false
+	for _, r := range result {
+		if r.Type == field.ErrorTypeInvalid && r.Field == "spec.source.git.uri" {
+			foundError = true
+			break
+		}
+	}
+	if !foundError {
+		t.Errorf("did not find expected error")
+	}
+}
+
+func TestBuildValidationWithSSHStyledURL(t *testing.T) {
+	build := &buildapi.Build{
+		ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: ""},
+		Spec: buildapi.BuildSpec{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
+						URI: "ssh://git@github.com:22/user/repo.git",
+					},
+				},
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{},
+				},
+				Output: buildapi.BuildOutput{
+					To: &kapi.ObjectReference{
+						Kind: "DockerImage",
+						Name: "repository/data",
+					},
+				},
+			},
+		},
+		Status: buildapi.BuildStatus{
+			Phase: buildapi.BuildPhaseNew,
+		},
+	}
+	result := ValidateBuild(build)
+	for _, r := range result {
+		if r.Field == "spec.source.git.uri" {
+			t.Errorf("Unexpected error with uri: %s", r.Detail)
+		}
+	}
+}
+
+func TestBuildValidationWithSCPStyledURL(t *testing.T) {
+	build := &buildapi.Build{
+		ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: ""},
+		Spec: buildapi.BuildSpec{
+			CommonSpec: buildapi.CommonSpec{
+				Source: buildapi.BuildSource{
+					Git: &buildapi.GitBuildSource{
+						URI: "git@github.com:sclorg/nodejs-ex",
+					},
+				},
+				Strategy: buildapi.BuildStrategy{
+					DockerStrategy: &buildapi.DockerBuildStrategy{},
+				},
+				Output: buildapi.BuildOutput{
+					To: &kapi.ObjectReference{
+						Kind: "DockerImage",
+						Name: "repository/data",
+					},
+				},
+			},
+		},
+		Status: buildapi.BuildStatus{
+			Phase: buildapi.BuildPhaseNew,
+		},
+	}
+	result := ValidateBuild(build)
+	for _, r := range result {
+		if r.Field == "spec.source.git.uri" {
+			t.Errorf("Unexpected error with uri: %s", r.Detail)
+		}
 	}
 }
 


### PR DESCRIPTION
we were just wrong with https://github.com/openshift/openshift-apiserver/pull/147

/assign @adambkaplan 

note with the redhat outage tests will fail, even unit (as there is an attempt to access registry.access.redhat.com in one of the tests)