### PR TITLE
Bug 1977414: return correct reason and message from failed build

### DIFF
--- a/pkg/build/apiserver/registry/buildconfiginstantiate/rest.go
+++ b/pkg/build/apiserver/registry/buildconfiginstantiate/rest.go
@@ -252,7 +252,7 @@ func (h *binaryInstantiateHandler) handle(r io.Reader) (runtime.Object, error) {
 	case latest.Status.Phase == buildv1.BuildPhaseFailed:
 		// don't cancel the build if it reached a terminal state on its own
 		cancel = false
-		errLog := fmt.Sprintf("build %s failed: %s: %s", build.Name, build.Status.Reason, build.Status.Message)
+		errLog := fmt.Sprintf("build %s failed: %s: %s", build.Name, latest.Status.Reason, latest.Status.Message)
 		klog.Warningf(errLog)
 		return nil, errors.NewBadRequest(errLog)
 	case latest.Status.Phase == buildv1.BuildPhaseCancelled:


### PR DESCRIPTION
When `Build` fails during `buildconfiginstantiate` (binary build), `status.reason`
and `status.message` are taken from the older state of the `Build` object, and they
are empty.

Must be taken from the new object obtained from `watch`.