### PR TITLE
Bug 1996140: Update RBAC event group to access new Events.event API

### DIFF
--- a/pkg/bootstrappolicy/controller_policy.go
+++ b/pkg/bootstrappolicy/controller_policy.go
@@ -274,7 +274,7 @@ func init() {
 			rbacv1helpers.NewRule("get", "update", "patch").Groups(deployGroup, legacyDeployGroup).Resources("deploymentconfigs").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "update").Groups(extensionsGroup, appsGroup).Resources("replicasets/scale", "deployments/scale").RuleOrDie(),
 			rbacv1helpers.NewRule("get", "update").Groups(deployGroup, legacyDeployGroup).Resources("deploymentconfigs/scale").RuleOrDie(),
-			rbacv1helpers.NewRule("watch", "list").Groups(kapiGroup).Resources("events").RuleOrDie(),
+			rbacv1helpers.NewRule("watch", "list").Groups(eventsGroup, legacyEventGroup).Resources("events").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -76,6 +76,7 @@ var (
 	legacyAuthzGroup    = ""
 	legacyBuildGroup    = ""
 	legacyDeployGroup   = ""
+	legacyEventGroup    = ""
 	legacyImageGroup    = ""
 	legacyProjectGroup  = ""
 	legacyQuotaGroup    = ""

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -2837,6 +2837,7 @@ items:
     - update
   - apiGroups:
     - ""
+    - events.k8s.io
     resources:
     - events
     verbs:


### PR DESCRIPTION
K8 is deprecating cores.Event API in-favour of
k8s.io events.Event API. In order to access this new API,
we must update a rule.

Signed-off-by: Martin Kennelly <mkennell@redhat.com>