### PR TITLE
Bug 2047335: fix panic from printer

### DIFF
--- a/pkg/project/printers/internalversion/printer.go
+++ b/pkg/project/printers/internalversion/printer.go
@@ -32,7 +32,7 @@ func printProject(project *projectapi.Project, options kprinters.GenerateOptions
 		Object: runtime.RawExtension{Object: project},
 	}
 
-	row.Cells = append(row.Cells, project.Name, project.Annotations[oapi.OpenShiftDisplayName], project.Status.Phase)
+	row.Cells = append(row.Cells, project.Name, project.Annotations[oapi.OpenShiftDisplayName], string(project.Status.Phase))
 
 	return []metav1.TableRow{row}, nil
 }


### PR DESCRIPTION
we see a panic when we are deep copying `TableRow` of `Project` type:
```
2022-01-27T15:02:37.171735296Z E0127 15:02:37.171633       1 runtime.go:76] Observed a panic: cannot deep copy core.NamespacePhase
```

We can trace it back to here:
https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/deepcopy.go#L33

and then here:
https://github.com/kubernetes/kubernetes/blob/9968b0eff06f109792e64f37ee92889711713a88/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go#L639


`Project.Status.Phase` is a `core.NamespacePhase` type, and `DeepCopyJSONValue` will panic if it is a type alias, it needs to be a string.

Now, why we didn't see this error before, I have not been able to find out yet.



