### PR TITLE
[release-4.8][ART-3664] Bug 2043808: IPs with leading zeros are still valid in the apiserver

### DIFF
--- a/images/Dockerfile.rhel
+++ b/images/Dockerfile.rhel
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-apiserver
 COPY . .
-RUN make build --warn-undefined-variables
+RUN make GOFLAGS='-mod=vendor -p=4 -tags=unsupportedGolang116OnlyUseDeprecatedParseIPv4' build --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/4.8:base
 COPY --from=builder /go/src/github.com/openshift/openshift-apiserver/openshift-apiserver /usr/bin/


### PR DESCRIPTION
backport of https://github.com/openshift/openshift-apiserver/pull/277
ref https://issues.redhat.com/browse/ART-3664

/assign tkashem