### PR TITLE
Bug 2053218: Fix importing images that have dots in their namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/openshift/apiserver-library-go v0.0.0-20211209162547-8c11dbc46b6e
 	github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20211216141749-1816407208cf
+	github.com/openshift/library-go v0.0.0-20220211142501-9f57c596fd46
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	go.etcd.io/etcd/client/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -568,8 +568,8 @@ github.com/openshift/docker-distribution v0.0.0-20180925154709-d4c35485a70d/go.m
 github.com/openshift/kubernetes-apiserver v0.0.0-20211221144435-1fd9911b75fd h1:7v5tXkWpYS2trvL40nENrAU/JunP/DZbM+mw8baPcB0=
 github.com/openshift/kubernetes-apiserver v0.0.0-20211221144435-1fd9911b75fd/go.mod h1:Bqt0gWbeM2NefS8CjWswwd2VNAKN6lUKR85Ft4gippY=
 github.com/openshift/library-go v0.0.0-20211209153216-ed9bc958bd8a/go.mod h1:M/Gi/GUUrMdSS07nrYtTiK43J6/VUAyk/+IfN4ZqUY4=
-github.com/openshift/library-go v0.0.0-20211216141749-1816407208cf h1:LfL5dbDoRE792MJoIBQcGAeScq2AHFzvY3iXWxCe2OI=
-github.com/openshift/library-go v0.0.0-20211216141749-1816407208cf/go.mod h1:hz4rpghzCaE+vejl9v04JdmrujaZA8BBpajosXfIGl8=
+github.com/openshift/library-go v0.0.0-20220211142501-9f57c596fd46 h1:3v3eX7FDmKOvuwri1BP0Zy1G7CMALWN+q/pkvxbs7CM=
+github.com/openshift/library-go v0.0.0-20220211142501-9f57c596fd46/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d h1:fLITXDjxMSvUDjnXs/zljIWktbST9+Om8XbrmmM7T4I=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d/go.mod h1:LJM49W8fBVSj+rvcopJZu9mgH5Tx6HwLHySIYeGeu4k=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/openshift/library-go/pkg/image/registryclient/client.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/registryclient/client.go
@@ -237,11 +237,18 @@ func (c *Context) Repository(ctx context.Context, registry *url.URL, repoName st
 	if err != nil {
 		return nil, err
 	}
-	ref, err := imagereference.Parse(repoName)
+
+	registryName := registry.Host
+	if registryName == "registry-1.docker.io" {
+		registryName = "docker.io"
+	}
+	fullReference := fmt.Sprintf("%s/%s", registryName, repoName)
+
+	ref, err := imagereference.Parse(fullReference)
 	if err != nil {
 		return nil, err
 	}
-	ref.Registry = registry.Host
+
 	locator := repositoryLocator{
 		named: named,
 		ref:   ref,

--- a/vendor/github.com/openshift/library-go/pkg/image/registryclient/client_mirrored.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/registryclient/client_mirrored.go
@@ -64,6 +64,7 @@ type blobMirroredRepoRetriever interface {
 
 // repositoryLocator caches the components necessary to connect to a single image repository.
 type repositoryLocator struct {
+	// ref is the full image reference as it is provided by the client.
 	ref reference.DockerImageReference
 	// url may specify a default protocol (http) instead of (https), but is otherwise calculated
 	// by taking ref.Registry and applying it to url.Host

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -515,7 +515,7 @@ github.com/openshift/client-go/user/informers/externalversions/internalinterface
 github.com/openshift/client-go/user/informers/externalversions/user
 github.com/openshift/client-go/user/informers/externalversions/user/v1
 github.com/openshift/client-go/user/listers/user/v1
-# github.com/openshift/library-go v0.0.0-20211216141749-1816407208cf
+# github.com/openshift/library-go v0.0.0-20220211142501-9f57c596fd46
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/apiserver/admission/admissionregistrationtesting
 github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig


### PR DESCRIPTION
Backport of #279.

This PR bumps library-go to get a new registryclient that can correctly
handle image references like

    registry.example.com/namespace.with.dot/foo