### PR TITLE
Bug 2053222: Fix importing images that have dots in their namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/openshift/apiserver-library-go v0.0.0-20211105081020-a4615a7a7678
 	github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37
 	github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7
-	github.com/openshift/library-go v0.0.0-20210831102543-1a08f0c3bd9a
+	github.com/openshift/library-go v0.0.0-20220211144658-96cd7a701be1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	go.etcd.io/etcd/client/v3 v3.5.0

--- a/go.sum
+++ b/go.sum
@@ -521,8 +521,9 @@ github.com/openshift/docker-distribution v0.0.0-20180925154709-d4c35485a70d h1:t
 github.com/openshift/docker-distribution v0.0.0-20180925154709-d4c35485a70d/go.mod h1:XmfFzbwryblvZ29NebonirM7RBuNEO7+yVCOapaouAk=
 github.com/openshift/kubernetes-apiserver v0.0.0-20211019154525-d47792cfd13b h1:wib/bP83nDZIMS5Eeqfznn+/oltwW0LCae1V41ycpK8=
 github.com/openshift/kubernetes-apiserver v0.0.0-20211019154525-d47792cfd13b/go.mod h1:vrpMmbyjWrgdyOvZTSpsusQq5iigKNWv9o9KlDAbBHI=
-github.com/openshift/library-go v0.0.0-20210831102543-1a08f0c3bd9a h1:6g4CJQBz+mcxdFk19QBplFf6y1xqe1LaUNzTqMOpCS0=
 github.com/openshift/library-go v0.0.0-20210831102543-1a08f0c3bd9a/go.mod h1:ymWf1TnfDo0LgjihlqHzYoy81pTY5wBL+bl3XdHNEYI=
+github.com/openshift/library-go v0.0.0-20220211144658-96cd7a701be1 h1:3Njyx2dc7FZsGX1uLNZmJYltsOZBLNqQvwofRprDBy0=
+github.com/openshift/library-go v0.0.0-20220211144658-96cd7a701be1/go.mod h1:5TSPiu4ZEPW5NwUspgqYqjSD/wF86JWGy+x8jB+9oB4=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d h1:fLITXDjxMSvUDjnXs/zljIWktbST9+Om8XbrmmM7T4I=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d/go.mod h1:LJM49W8fBVSj+rvcopJZu9mgH5Tx6HwLHySIYeGeu4k=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/openshift/library-go/pkg/crypto/missing_san.go
+++ b/vendor/github.com/openshift/library-go/pkg/crypto/missing_san.go
@@ -1,0 +1,40 @@
+package crypto
+
+import (
+	"crypto/x509"
+	"errors"
+	"strings"
+)
+
+// CertHasSAN returns true if the given certificate includes a SAN field, else false.
+func CertHasSAN(c *x509.Certificate) bool {
+	if c == nil {
+		return false
+	}
+
+	sanOID := []int{2, 5, 29, 17}
+
+	for i := range c.Extensions {
+		if c.Extensions[i].Id.Equal(sanOID) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsHostnameError returns true if the error indicates a host name error about legacy CN fields
+// else false as a result of `x509.Certificate#VerifyHostname`.
+//
+// For Golang <1.17: If GODEBUG=x509ignoreCN=0 is set this will always return false.
+// In this case, use `crypto.CertHasSAN` to assert validity of the certificate directly.
+//
+// See https://github.com/golang/go/blob/go1.16.12/src/crypto/x509/verify.go#L119
+func IsHostnameError(err error) bool {
+	if err != nil &&
+		errors.As(err, &x509.HostnameError{}) &&
+		strings.Contains(err.Error(), "x509: certificate relies on legacy Common Name field") {
+		return true
+	}
+
+	return false
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/registryclient/client.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/registryclient/client.go
@@ -236,11 +236,18 @@ func (c *Context) Repository(ctx context.Context, registry *url.URL, repoName st
 	if err != nil {
 		return nil, err
 	}
-	ref, err := imagereference.Parse(repoName)
+
+	registryName := registry.Host
+	if registryName == "registry-1.docker.io" {
+		registryName = "docker.io"
+	}
+	fullReference := fmt.Sprintf("%s/%s", registryName, repoName)
+
+	ref, err := imagereference.Parse(fullReference)
 	if err != nil {
 		return nil, err
 	}
-	ref.Registry = registry.Host
+
 	locator := repositoryLocator{
 		named: named,
 		ref:   ref,

--- a/vendor/github.com/openshift/library-go/pkg/image/registryclient/client_mirrored.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/registryclient/client_mirrored.go
@@ -2,12 +2,16 @@ package registryclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
 
 	"github.com/docker/distribution"
+	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/docker/distribution/registry/client"
+	"github.com/docker/distribution/registry/client/auth"
 	"github.com/opencontainers/go-digest"
 	"github.com/openshift/library-go/pkg/image/reference"
 	"k8s.io/klog/v2"
@@ -60,6 +64,7 @@ type blobMirroredRepoRetriever interface {
 
 // repositoryLocator caches the components necessary to connect to a single image repository.
 type repositoryLocator struct {
+	// ref is the full image reference as it is provided by the client.
 	ref reference.DockerImageReference
 	// url may specify a default protocol (http) instead of (https), but is otherwise calculated
 	// by taking ref.Registry and applying it to url.Host
@@ -185,6 +190,21 @@ func (r *blobMirroredRepository) attemptRepos(ctx context.Context, repos []refer
 	return firstErr
 }
 
+// isRequestError reports whether the registry rejected the request or was not
+// able to serve any data. True for an error from io.Copy indicates that
+// nothing was copied.
+func isRequestError(err error) bool {
+	var errorCode errcode.ErrorCode
+	responseError := &client.UnexpectedHTTPResponseError{}
+	statusError := &client.UnexpectedHTTPStatusError{}
+	return errors.As(err, &errcode.Errors{}) ||
+		errors.As(err, &errcode.Error{}) ||
+		errors.As(err, &errorCode) ||
+		errors.As(err, &responseError) ||
+		errors.As(err, &statusError) ||
+		errors.Is(err, auth.ErrNoBasicAuthCredentials)
+}
+
 // attemptFirstConnectedRepo will invoke fn on the first repo that successfully connects.
 func (r *blobMirroredRepository) attemptFirstConnectedRepo(ctx context.Context, repos []reference.DockerImageReference, fn func(r RepositoryWithLocation) error) error {
 	var firstErr error
@@ -197,7 +217,21 @@ func (r *blobMirroredRepository) attemptFirstConnectedRepo(ctx context.Context, 
 			}
 			continue
 		}
-		return fn(repo)
+		if err := fn(repo); err != nil {
+			if !isRequestError(err) {
+				// The request may have been halfway through
+				// and we cannot make another attempt.
+				return err
+			}
+			// The registry replied with an error like 4xx or 5xx,
+			// i.e. it hasn't served the blob and we can make
+			// another attempt with a different registry.
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		return nil
 	}
 	return firstErr
 }
@@ -419,6 +453,7 @@ func (f blobMirroredBlobstore) Stat(ctx context.Context, dgst digest.Digest) (di
 	err := f.repo.alternates(ctx, func(r RepositoryWithLocation) error {
 		var err error
 		desc, err = r.Blobs(ctx).Stat(ctx, dgst)
+		klog.V(5).Infof("stat for %s served from %s: %v", dgst, r.Named(), err)
 		return err
 	})
 	return desc, err
@@ -426,7 +461,9 @@ func (f blobMirroredBlobstore) Stat(ctx context.Context, dgst digest.Digest) (di
 
 func (f blobMirroredBlobstore) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
 	err := f.repo.firstConnectedAlternate(ctx, func(r RepositoryWithLocation) error {
-		return r.Blobs(ctx).ServeBlob(ctx, w, req, dgst)
+		err := r.Blobs(ctx).ServeBlob(ctx, w, req, dgst)
+		klog.V(5).Infof("blob %s served from %s: %v", dgst, r.Named(), err)
+		return err
 	})
 	return err
 }
@@ -436,6 +473,16 @@ func (f blobMirroredBlobstore) Open(ctx context.Context, dgst digest.Digest) (di
 	err := f.repo.alternates(ctx, func(r RepositoryWithLocation) error {
 		var err error
 		rsc, err = r.Blobs(ctx).Open(ctx, dgst)
+		if err != nil {
+			klog.V(5).Infof("open %s from %s: %v", dgst, r.Named(), err)
+			return err
+		}
+
+		// Distribution's implementation of Open doesn't send any requests to
+		// the registry. We need the reader to send a request to see if the
+		// registry can serve the blob.
+		_, err = rsc.Read([]byte{})
+		klog.V(5).Infof("open (read) %s from %s: %v", dgst, r.Named(), err)
 		return err
 	})
 	return rsc, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -420,7 +420,7 @@ github.com/openshift/client-go/user/informers/externalversions/internalinterface
 github.com/openshift/client-go/user/informers/externalversions/user
 github.com/openshift/client-go/user/informers/externalversions/user/v1
 github.com/openshift/client-go/user/listers/user/v1
-# github.com/openshift/library-go v0.0.0-20210831102543-1a08f0c3bd9a
+# github.com/openshift/library-go v0.0.0-20220211144658-96cd7a701be1
 ## explicit
 github.com/openshift/library-go/pkg/apiserver/admission/admissionregistrationtesting
 github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig


### PR DESCRIPTION
Backport of #281.

This PR bumps library-go to get a new registryclient that can correctly
handle image references like

    registry.example.com/namespace.with.dot/foo