### PR TITLE
Bug 2053223: Fix importing images that have dots in their namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/openshift/apiserver-library-go v0.0.0-20211111022136-bfb62ec0e419
 	github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
-	github.com/openshift/library-go v0.0.0-20210521084623-7392ea9b02ca
+	github.com/openshift/library-go v0.0.0-20220211152057-bc7588408098
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489

--- a/go.sum
+++ b/go.sum
@@ -537,8 +537,9 @@ github.com/openshift/docker-distribution v0.0.0-20180925154709-d4c35485a70d h1:t
 github.com/openshift/docker-distribution v0.0.0-20180925154709-d4c35485a70d/go.mod h1:XmfFzbwryblvZ29NebonirM7RBuNEO7+yVCOapaouAk=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210527175848-55ee66589915 h1:sFX4VkwXx4bv3YxceFO5PMtRbZxiVi5BiPDCcAN8GxE=
 github.com/openshift/kubernetes-apiserver v0.0.0-20210527175848-55ee66589915/go.mod h1:w2YSn4/WIwYuxG5zJmcqtRdtqgW/J2JRgFAqps3bBpg=
-github.com/openshift/library-go v0.0.0-20210521084623-7392ea9b02ca h1:NtRAdQTnE4B+UESOUaCSX3dw1uc+PpI1h2X7hUmE/5A=
 github.com/openshift/library-go v0.0.0-20210521084623-7392ea9b02ca/go.mod h1:87ZYjEncF0YNUKNzncb8Fiw8yFNevpIWZW83C/etzpw=
+github.com/openshift/library-go v0.0.0-20220211152057-bc7588408098 h1:hxhKI9HKY7wQJ3tgc5soiROIdr2EelsG7hbRK9/bPIY=
+github.com/openshift/library-go v0.0.0-20220211152057-bc7588408098/go.mod h1:C5DDOSPucn3EVA0T05fODKtAweTObMBrTYm/G3uUBI8=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d h1:fLITXDjxMSvUDjnXs/zljIWktbST9+Om8XbrmmM7T4I=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d/go.mod h1:LJM49W8fBVSj+rvcopJZu9mgH5Tx6HwLHySIYeGeu4k=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -1108,6 +1109,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15 h1:4uqm9Mv+w2MmB
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/controller-tools v0.2.8/go.mod h1:9VKHPszmf2DHz/QmHkcfZoewO6BL7pPs9uAiBVsaJSE=
 sigs.k8s.io/kube-storage-version-migrator v0.0.3/go.mod h1:mXfSLkx9xbJHQsgNDDUZK/iQTs2tMbx/hsJlWe6Fthw=
+sigs.k8s.io/kube-storage-version-migrator v0.0.4/go.mod h1:mXfSLkx9xbJHQsgNDDUZK/iQTs2tMbx/hsJlWe6Fthw=
 sigs.k8s.io/kustomize/api v0.8.5 h1:bfCXGXDAbFbb/Jv5AhMj2BB8a5VAJuuQ5/KU69WtDjQ=
 sigs.k8s.io/kustomize/api v0.8.5/go.mod h1:M377apnKT5ZHJS++6H4rQoCHmWtt6qTpp3mbe7p6OLY=
 sigs.k8s.io/kustomize/cmd/config v0.9.7/go.mod h1:MvXCpHs77cfyxRmCNUQjIqCmZyYsbn5PyQpWiq44nW0=

--- a/vendor/github.com/openshift/library-go/pkg/image/registryclient/client.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/registryclient/client.go
@@ -1,6 +1,7 @@
 package registryclient
 
 import (
+	"context"
 	"fmt"
 	"hash"
 	"io"
@@ -12,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 
 	"k8s.io/klog/v2"
@@ -26,7 +26,15 @@ import (
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/opencontainers/go-digest"
+
+	imagereference "github.com/openshift/library-go/pkg/image/reference"
 )
+
+// CredentialStoreFactory is any entity capable of creating a CredentialStore based on an image
+// path (such as quay.io/fedora/fedora).
+type CredentialStoreFactory interface {
+	CredentialStoreFor(image string) auth.CredentialStore
+}
 
 // RepositoryRetriever fetches a Docker distribution.Repository.
 type RepositoryRetriever interface {
@@ -71,15 +79,17 @@ type transportCache struct {
 }
 
 type Context struct {
-	Transport         http.RoundTripper
-	InsecureTransport http.RoundTripper
-	Challenges        challenge.Manager
-	Scopes            []auth.Scope
-	Actions           []string
-	Retries           int
-	Credentials       auth.CredentialStore
-	RequestModifiers  []transport.RequestModifier
-	Limiter           *rate.Limiter
+	Transport          http.RoundTripper
+	InsecureTransport  http.RoundTripper
+	Challenges         challenge.Manager
+	Scopes             []auth.Scope
+	Actions            []string
+	Retries            int
+	Credentials        auth.CredentialStore
+	CredentialsFactory CredentialStoreFactory
+	RequestModifiers   []transport.RequestModifier
+	Limiter            *rate.Limiter
+	Alternates         AlternateBlobSourceStrategy
 
 	DisableDigestVerification bool
 
@@ -135,6 +145,16 @@ func (c *Context) WithActions(actions ...string) *Context {
 
 func (c *Context) WithCredentials(credentials auth.CredentialStore) *Context {
 	c.Credentials = credentials
+	return c
+}
+
+func (c *Context) WithCredentialsFactory(factory CredentialStoreFactory) *Context {
+	c.CredentialsFactory = factory
+	return c
+}
+
+func (c *Context) WithAlternateBlobSourceStrategy(alternateStrategy AlternateBlobSourceStrategy) *Context {
+	c.Alternates = alternateStrategy
 	return c
 }
 
@@ -200,18 +220,75 @@ func (c *Context) Ping(ctx context.Context, registry *url.URL, insecure bool) (h
 	return t, &src, nil
 }
 
+// RepositoryForRef returns a distribution.Repository against the provided image reference. If insecure
+// is true, HTTP connections are allowed and HTTPS certificate verification errors will be ignored. The returned
+// Repository instance is threadsafe but the ManifestService, TagService, or BlobService are not.
+func (c *Context) RepositoryForRef(ctx context.Context, ref imagereference.DockerImageReference, insecure bool) (distribution.Repository, error) {
+	return c.connectToRegistry(ctx, repositoryLocator{ref: ref}, insecure)
+}
+
+// Repository returns a distribution.Repository against the provided registry and repository name. If insecure
+// is true, HTTP connections are allowed and HTTPS certificate verification errors will be ignored. The returned
+// Repository instance is threadsafe but the ManifestService, TagService, or BlobService are not. Note - the caller
+// is responsible for providing a valid registry url for docker.io - use RepositoryForRef() to avoid that.
 func (c *Context) Repository(ctx context.Context, registry *url.URL, repoName string, insecure bool) (distribution.Repository, error) {
 	named, err := reference.WithName(repoName)
 	if err != nil {
 		return nil, err
 	}
 
-	rt, src, err := c.Ping(ctx, registry, insecure)
+	registryName := registry.Host
+	if registryName == "registry-1.docker.io" {
+		registryName = "docker.io"
+	}
+	fullReference := fmt.Sprintf("%s/%s", registryName, repoName)
+
+	ref, err := imagereference.Parse(fullReference)
 	if err != nil {
 		return nil, err
 	}
 
-	rt = c.repositoryTransport(rt, src, repoName)
+	locator := repositoryLocator{
+		named: named,
+		ref:   ref,
+		url:   registry,
+	}
+	return &blobMirroredRepository{
+		locator:   locator,
+		insecure:  insecure,
+		strategy:  c.Alternates,
+		retriever: c,
+	}, nil
+}
+
+// connectToRegistry is private and returns a non-wrapped, non-mirrorable repository.
+func (c *Context) connectToRegistry(ctx context.Context, locator repositoryLocator, insecure bool) (RepositoryWithLocation, error) {
+	var named reference.Named = locator.named
+	var registryURL *url.URL = locator.url
+	var path string
+
+	// ensure the values needed from the locator are defaulted
+	if named == nil {
+		path = locator.ref.RepositoryName()
+		var err error
+		named, err = reference.WithName(path)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		path = reference.Path(named)
+	}
+	if registryURL == nil {
+		registryURL = locator.ref.RegistryURL()
+	}
+
+	// attempt to connect to the registry to get auth instructions
+	rt, src, err := c.Ping(ctx, registryURL, insecure)
+	if err != nil {
+		return nil, err
+	}
+
+	rt = c.repositoryTransport(rt, src, path, locator.ref)
 
 	repo, err := registryclient.NewRepository(named, src.String(), rt)
 	if err != nil {
@@ -224,7 +301,7 @@ func (c *Context) Repository(ctx context.Context, registry *url.URL, repoName st
 	if limiter == nil {
 		limiter = rate.NewLimiter(rate.Limit(5), 5)
 	}
-	return NewLimitedRetryRepository(repo, c.Retries, limiter), nil
+	return NewLimitedRetryRepository(locator.ref, repo, c.Retries, limiter), nil
 }
 
 func (c *Context) ping(registry url.URL, insecure bool, transport http.RoundTripper) (*url.URL, error) {
@@ -290,7 +367,7 @@ func (s stringScope) String() string { return string(s) }
 // cachedTransport reuses an underlying transport for the given round tripper based
 // on the set of passed scopes. It will always return a transport that has at least the
 // provided scope list.
-func (c *Context) cachedTransport(rt http.RoundTripper, host string, scopes []auth.Scope) http.RoundTripper {
+func (c *Context) cachedTransport(rt http.RoundTripper, host string, scopes []auth.Scope, ref imagereference.DockerImageReference) http.RoundTripper {
 	scopeNames := make(map[string]struct{})
 	for _, scope := range scopes {
 		scopeNames[scope.String()] = struct{}{}
@@ -315,6 +392,11 @@ func (c *Context) cachedTransport(rt http.RoundTripper, host string, scopes []au
 		scopes = append(scopes, stringScope(s))
 	}
 
+	creds := c.Credentials
+	if c.CredentialsFactory != nil {
+		creds = c.CredentialsFactory.CredentialStoreFor(ref.AsRepository().String())
+	}
+
 	modifiers := []transport.RequestModifier{
 		// TODO: slightly smarter authorizer that retries unauthenticated requests
 		// TODO: make multiple attempts if the first credential fails
@@ -322,10 +404,10 @@ func (c *Context) cachedTransport(rt http.RoundTripper, host string, scopes []au
 			c.Challenges,
 			auth.NewTokenHandlerWithOptions(auth.TokenHandlerOptions{
 				Transport:   rt,
-				Credentials: c.Credentials,
+				Credentials: creds,
 				Scopes:      scopes,
 			}),
-			auth.NewBasicHandler(c.Credentials),
+			auth.NewBasicHandler(creds),
 		),
 	}
 	modifiers = append(modifiers, c.RequestModifiers...)
@@ -350,8 +432,8 @@ func (c *Context) scopes(repoName string) []auth.Scope {
 	return scopes
 }
 
-func (c *Context) repositoryTransport(t http.RoundTripper, registry *url.URL, repoName string) http.RoundTripper {
-	return c.cachedTransport(t, registry.Host, c.scopes(repoName))
+func (c *Context) repositoryTransport(t http.RoundTripper, registry *url.URL, repoName string, ref imagereference.DockerImageReference) http.RoundTripper {
+	return c.cachedTransport(t, registry.Host, c.scopes(repoName), ref)
 }
 
 var nowFn = time.Now
@@ -359,6 +441,7 @@ var nowFn = time.Now
 type retryRepository struct {
 	distribution.Repository
 
+	ref     imagereference.DockerImageReference
 	limiter *rate.Limiter
 	retries int
 	sleepFn func(time.Duration)
@@ -366,14 +449,19 @@ type retryRepository struct {
 
 // NewLimitedRetryRepository wraps a distribution.Repository with helpers that will retry temporary failures
 // over a limited time window and duration, and also obeys a rate limit.
-func NewLimitedRetryRepository(repo distribution.Repository, retries int, limiter *rate.Limiter) distribution.Repository {
+func NewLimitedRetryRepository(ref imagereference.DockerImageReference, repo distribution.Repository, retries int, limiter *rate.Limiter) RepositoryWithLocation {
 	return &retryRepository{
 		Repository: repo,
 
+		ref:     ref,
 		limiter: limiter,
 		retries: retries,
 		sleepFn: time.Sleep,
 	}
+}
+
+func (r *retryRepository) Ref() imagereference.DockerImageReference {
+	return r.ref
 }
 
 // isTemporaryHTTPError returns true if the error indicates a temporary or partial HTTP failure

--- a/vendor/github.com/openshift/library-go/pkg/image/registryclient/client_mirrored.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/registryclient/client_mirrored.go
@@ -1,0 +1,528 @@
+package registryclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/docker/distribution"
+	"github.com/opencontainers/go-digest"
+	"github.com/openshift/library-go/pkg/image/reference"
+	"k8s.io/klog/v2"
+
+	distributionreference "github.com/docker/distribution/reference"
+)
+
+// AlternateBlobSourceStrategy is consulted when a repository cannot be reached to find alternate
+// repositories that may be able to serve a given content-addressed blob. The strategy is consulted
+// at most twice - once before any request is made to a given repository. If FirstRequest() returns a
+// list of alternates, OnFailure is not invoked.
+type AlternateBlobSourceStrategy interface {
+	// FirstRequest returns the set of locations that should be searched in a preferred order. If locator
+	// is not included in the response it will not be searched. If alternateRepositories is an empty list
+	// no lookup will be performed and requests will exit with an error. If alternateRepositories is nil
+	// and err is nil, OnFailure will be invoked if the first request fails.
+	FirstRequest(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error)
+	// OnFailure is invoked if FirstRequest returned no error and a nil list of locations if and only if
+	// an API call fails on the specified request. The result of alternateRepositories is cached for
+	// subsequent calls to that repository.
+	OnFailure(ctx context.Context, locator reference.DockerImageReference) (alternateRepositories []reference.DockerImageReference, err error)
+}
+
+// ManifestWithLocationService extends the ManifestService to allow clients to retrieve a manifest and
+// get the location of the mirrored manifest. Not all ManifestServices returned from a Repository will
+// support this interface and it must be conditional.
+type ManifestWithLocationService interface {
+	distribution.ManifestService
+
+	// GetWithLocation returns the registry URL the provided manifest digest was retrieved from which may be Repository.Named(),
+	// or one of the blob mirrors if alternate location for blob sources was provided. It returns an error if the digest could not be
+	// located - if an error is returned the source reference (Repository.Named()) will be set.
+	GetWithLocation(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, reference.DockerImageReference, error)
+}
+
+// RepositoryWithLocation extends the Repository and allows clients to know which repository registry this talks to
+// as primary (as a complement to Named() which does not include the URL).
+type RepositoryWithLocation interface {
+	distribution.Repository
+
+	// Ref returns the DockerImageReference representing this repository.
+	Ref() reference.DockerImageReference
+}
+
+// blobMirroredRepoRetriever allows a caller to retrieve a distribution.Repository. It may perform
+// requests to authorize the client and will return an error if it fails.
+type blobMirroredRepoRetriever interface {
+	connectToRegistry(context.Context, repositoryLocator, bool) (RepositoryWithLocation, error)
+}
+
+// repositoryLocator caches the components necessary to connect to a single image repository.
+type repositoryLocator struct {
+	// ref is the full image reference as it is provided by the client.
+	ref reference.DockerImageReference
+	// url may specify a default protocol (http) instead of (https), but is otherwise calculated
+	// by taking ref.Registry and applying it to url.Host
+	url *url.URL
+	// named is the image repository path on the server (namespace and name in ref terms) and is
+	// required for the distribution registryclient.
+	named distributionreference.Named
+}
+
+// blobMirroredRepository provides failover lookup behavior for blobs in a given repository on
+// errors by delegating to the provided strategy for the first request or when a failure occurs.
+// The strategy is expected to return a set of alternate locations to consume content from,
+// which may not include the original source. Only requests made for content addressable blobs
+// may be consulted in this fashion (anything via digest) - everything else must use source().
+type blobMirroredRepository struct {
+	locator  repositoryLocator
+	insecure bool
+
+	strategy  AlternateBlobSourceStrategy
+	retriever blobMirroredRepoRetriever
+
+	lock  sync.Mutex
+	order []reference.DockerImageReference
+	repos map[reference.DockerImageReference]RepositoryWithLocation
+}
+
+// Named returns the name of the repository.
+func (r *blobMirroredRepository) Named() distributionreference.Named {
+	return r.locator.named
+}
+
+// Named returns the name of the repository.
+func (r *blobMirroredRepository) Ref() reference.DockerImageReference {
+	return r.locator.ref
+}
+
+// Manifests wraps the manifest service in a blobMirroredManifest for shared retries.
+func (r *blobMirroredRepository) Manifests(ctx context.Context, options ...distribution.ManifestServiceOption) (distribution.ManifestService, error) {
+	return &blobMirroredManifest{repo: r, options: options}, nil
+}
+
+// Blobs wraps the blob service in a blobMirroredBlobstore for shared retries.
+func (r *blobMirroredRepository) Blobs(ctx context.Context) distribution.BlobStore {
+	return blobMirroredBlobstore{repo: r}
+}
+
+// Tags lists the tags under the named repository.
+func (r *blobMirroredRepository) Tags(ctx context.Context) distribution.TagService {
+	return blobMirroredTags{repo: r}
+}
+
+var (
+	errNoValidAlternates = fmt.Errorf("no valid alterative sources for this content located")
+	errNoValidSource     = fmt.Errorf("no source repository defined for accessing the repository")
+)
+
+// initialRepos returns a list of locations to attempt to access, a boolean indicating that alternates
+// were suggested, or an error.
+func (r *blobMirroredRepository) initialRepos(ctx context.Context) ([]reference.DockerImageReference, bool, error) {
+	if r.strategy == nil {
+		return []reference.DockerImageReference{r.locator.ref}, false, nil
+	}
+
+	// protect FirstRequest being called only one at a time and r.order writes
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.order != nil {
+		return r.order, true, nil
+	}
+	alternates, err := r.strategy.FirstRequest(ctx, r.locator.ref)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(alternates) == 0 {
+		return []reference.DockerImageReference{r.locator.ref}, false, nil
+	}
+	r.order = alternates
+	return r.order, len(alternates) > 0, nil
+}
+
+// errorRepos returns a list of alternate registries to search for the provided content.
+func (r *blobMirroredRepository) errorRepos(ctx context.Context) ([]reference.DockerImageReference, error) {
+	if r.strategy == nil {
+		return nil, nil
+	}
+
+	// TODO: potentially filter certain types of errors, maybe even per method type, if we ever
+	// retry non-idempotent operations
+	// protect OnFailure being called one at a time and r.order writes
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.order != nil {
+		return nil, nil
+	}
+	alternates, err := r.strategy.OnFailure(ctx, r.locator.ref)
+	if err != nil {
+		return nil, err
+	}
+	r.order = alternates
+	return r.order, nil
+}
+
+// attemptRepos will invoke fn on all repos until fn returns no error. fn is expected to be idempotent.
+func (r *blobMirroredRepository) attemptRepos(ctx context.Context, repos []reference.DockerImageReference, fn func(r RepositoryWithLocation) error) error {
+	var firstErr error
+	for _, ref := range repos {
+		klog.V(5).Infof("Attempting to connect to %s", ref)
+		repo, err := r.connect(ctx, ref)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if err := fn(repo); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		return nil
+	}
+	return firstErr
+}
+
+// attemptFirstConnectedRepo will invoke fn on the first repo that successfully connects.
+func (r *blobMirroredRepository) attemptFirstConnectedRepo(ctx context.Context, repos []reference.DockerImageReference, fn func(r RepositoryWithLocation) error) error {
+	var firstErr error
+	for _, ref := range repos {
+		klog.V(5).Infof("Attempting to connect to %s", ref)
+		repo, err := r.connect(ctx, ref)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		return fn(repo)
+	}
+	return firstErr
+}
+
+// alternates accesses the set of repositories that may be valid alternatives for accessing content
+func (r *blobMirroredRepository) alternates(ctx context.Context, fn func(r RepositoryWithLocation) error) error {
+	repos, loaded, err := r.initialRepos(ctx)
+	if err != nil {
+		return err
+	}
+	if attemptErr := r.attemptRepos(ctx, repos, fn); attemptErr != nil {
+		if loaded {
+			return attemptErr
+		}
+		alternates, err := r.errorRepos(ctx)
+		if err != nil {
+			return err
+		}
+		if len(alternates) == 0 {
+			return attemptErr
+		}
+		if alternateErr := r.attemptRepos(ctx, alternates, fn); alternateErr != nil {
+			return attemptErr
+		}
+	}
+	return nil
+}
+
+// firstConnectedAlternate invokes fn on the first alternate that can be connected to. Use when the
+// function can only be invoked once (such as a method with side effects, like ServeBlob which writes
+// to the response).
+func (r *blobMirroredRepository) firstConnectedAlternate(ctx context.Context, fn func(r RepositoryWithLocation) error) error {
+	repos, loaded, err := r.initialRepos(ctx)
+	if err != nil {
+		return err
+	}
+	if len(repos) == 0 {
+		return errNoValidAlternates
+	}
+	if attemptErr := r.attemptFirstConnectedRepo(ctx, repos, fn); attemptErr != nil {
+		if loaded {
+			return attemptErr
+		}
+		alternates, err := r.errorRepos(ctx)
+		if err != nil {
+			return err
+		}
+		if alternateErr := r.attemptFirstConnectedRepo(ctx, alternates, fn); alternateErr != nil {
+			return attemptErr
+		}
+	}
+	return nil
+}
+
+// source connects to the original repository or returns an error. It will always use the same value
+// of insecure as the original repository. Use when the request should only go to the initial repo.
+func (r *blobMirroredRepository) source(ctx context.Context, fn func(r distribution.Repository) error) error {
+	repo, err := r.connect(ctx, r.locator.ref)
+	if err != nil {
+		return err
+	}
+	return fn(repo)
+}
+
+// connect reuses or creates a connection to the provided reference, returning a repository instance
+// or an error. This method expects that the connection only talks to the provided registry.
+func (r *blobMirroredRepository) connect(ctx context.Context, ref reference.DockerImageReference) (RepositoryWithLocation, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	repo, ok := r.repos[ref]
+	if ok {
+		return repo, nil
+	}
+	locator := repositoryLocator{
+		ref: ref,
+	}
+	repo, err := r.retriever.connectToRegistry(ctx, locator, ref != r.locator.ref || r.insecure)
+	if err != nil {
+		return nil, err
+	}
+	if r.repos == nil {
+		r.repos = make(map[reference.DockerImageReference]RepositoryWithLocation)
+	}
+	r.repos[ref] = repo
+	return repo, nil
+}
+
+// blobMirroredManifest will sequentially retry manifest operations on a set of repositories determined
+// by the repository list, caching manifest services locally as needed (manifest service is assumed
+// to have local state and does so in the registry client). The individual manifest service is not
+// thread safe, but methods on this interface are thread safe.
+type blobMirroredManifest struct {
+	repo    *blobMirroredRepository
+	options []distribution.ManifestServiceOption
+
+	lock  sync.Mutex
+	cache map[distribution.Repository]distribution.ManifestService
+}
+
+var _ distribution.ManifestService = &blobMirroredManifest{}
+var _ ManifestWithLocationService = &blobMirroredManifest{}
+
+// init retrieves or caches a manifets service for the provided repository, since each manifest
+// service has local state.
+func (f *blobMirroredManifest) init(ctx context.Context, r distribution.Repository) (distribution.ManifestService, error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	ms := f.cache[r]
+	if ms != nil {
+		return ms, nil
+	}
+	ms, err := r.Manifests(ctx, f.options...)
+	if err != nil {
+		return nil, err
+	}
+	if f.cache == nil {
+		f.cache = make(map[distribution.Repository]distribution.ManifestService)
+	}
+	f.cache[r] = ms
+	return ms, nil
+}
+
+// alternates invokes fn once per alternate repo until fn returns without error.
+func (f *blobMirroredManifest) alternates(ctx context.Context, fn func(m distribution.ManifestService, repo RepositoryWithLocation) error) error {
+	return f.repo.alternates(ctx, func(repo RepositoryWithLocation) error {
+		ms, err := f.init(ctx, repo)
+		if err != nil {
+			return err
+		}
+		return fn(ms, repo)
+	})
+}
+
+// source invokes fn against the primary location.
+func (f *blobMirroredManifest) source(ctx context.Context, fn func(r distribution.ManifestService) error) error {
+	return f.repo.source(ctx, func(r distribution.Repository) error {
+		ms, err := f.init(ctx, r)
+		if err != nil {
+			return err
+		}
+		return fn(ms)
+	})
+}
+
+func (f *blobMirroredManifest) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (digest.Digest, error) {
+	var dgst digest.Digest
+	err := f.source(ctx, func(r distribution.ManifestService) error {
+		var err error
+		dgst, err = r.Put(ctx, manifest, options...)
+		return err
+	})
+	return dgst, err
+}
+
+func (f *blobMirroredManifest) Delete(ctx context.Context, dgst digest.Digest) error {
+	return f.source(ctx, func(r distribution.ManifestService) error {
+		return r.Delete(ctx, dgst)
+	})
+}
+
+func (f *blobMirroredManifest) Exists(ctx context.Context, dgst digest.Digest) (bool, error) {
+	var ok bool
+	err := f.alternates(ctx, func(m distribution.ManifestService, repo RepositoryWithLocation) error {
+		var err error
+		ok, err = m.Exists(ctx, dgst)
+		return err
+	})
+	return ok, err
+}
+
+func (f *blobMirroredManifest) Get(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, error) {
+	var manifest distribution.Manifest
+	err := f.alternates(ctx, func(m distribution.ManifestService, repo RepositoryWithLocation) error {
+		var err error
+		manifest, err = m.Get(ctx, dgst, options...)
+		klog.V(5).Infof("get manifest for %s served from %#v: %v", dgst, m, err)
+		return err
+	})
+	return manifest, err
+}
+
+func (f *blobMirroredManifest) GetWithLocation(ctx context.Context, dgst digest.Digest, options ...distribution.ManifestServiceOption) (distribution.Manifest, reference.DockerImageReference, error) {
+	var manifest distribution.Manifest
+	var ref = f.repo.locator.ref
+	err := f.alternates(ctx, func(m distribution.ManifestService, repo RepositoryWithLocation) error {
+		var err error
+		manifest, err = m.Get(ctx, dgst, options...)
+		klog.V(5).Infof("get manifest for %s served from %#v: %v", dgst, m, err)
+		if err == nil {
+			ref = repo.Ref()
+		}
+		return err
+	})
+	return manifest, ref, err
+}
+
+// blobMirroredBlobstore wraps the blob store and invokes retries on the repo.
+type blobMirroredBlobstore struct {
+	repo *blobMirroredRepository
+}
+
+var _ distribution.BlobService = blobMirroredBlobstore{}
+
+func (f blobMirroredBlobstore) Get(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	var data []byte
+	err := f.repo.alternates(ctx, func(r RepositoryWithLocation) error {
+		var err error
+		data, err = r.Blobs(ctx).Get(ctx, dgst)
+		klog.V(5).Infof("get for %s served from %s: %v", dgst, r.Named(), err)
+		return err
+	})
+	return data, err
+}
+
+func (f blobMirroredBlobstore) Stat(ctx context.Context, dgst digest.Digest) (distribution.Descriptor, error) {
+	var desc distribution.Descriptor
+	err := f.repo.alternates(ctx, func(r RepositoryWithLocation) error {
+		var err error
+		desc, err = r.Blobs(ctx).Stat(ctx, dgst)
+		return err
+	})
+	return desc, err
+}
+
+func (f blobMirroredBlobstore) ServeBlob(ctx context.Context, w http.ResponseWriter, req *http.Request, dgst digest.Digest) error {
+	err := f.repo.firstConnectedAlternate(ctx, func(r RepositoryWithLocation) error {
+		return r.Blobs(ctx).ServeBlob(ctx, w, req, dgst)
+	})
+	return err
+}
+
+func (f blobMirroredBlobstore) Open(ctx context.Context, dgst digest.Digest) (distribution.ReadSeekCloser, error) {
+	var rsc distribution.ReadSeekCloser
+	err := f.repo.alternates(ctx, func(r RepositoryWithLocation) error {
+		var err error
+		rsc, err = r.Blobs(ctx).Open(ctx, dgst)
+		return err
+	})
+	return rsc, err
+}
+
+func (f blobMirroredBlobstore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (distribution.BlobWriter, error) {
+	var bw distribution.BlobWriter
+	err := f.repo.source(ctx, func(r distribution.Repository) error {
+		var err error
+		bw, err = r.Blobs(ctx).Create(ctx, options...)
+		return err
+	})
+	return bw, err
+}
+
+func (f blobMirroredBlobstore) Put(ctx context.Context, mediaType string, p []byte) (distribution.Descriptor, error) {
+	var desc distribution.Descriptor
+	err := f.repo.source(ctx, func(r distribution.Repository) error {
+		var err error
+		desc, err = r.Blobs(ctx).Put(ctx, mediaType, p)
+		return err
+	})
+	return desc, err
+}
+
+func (f blobMirroredBlobstore) Resume(ctx context.Context, id string) (distribution.BlobWriter, error) {
+	var bw distribution.BlobWriter
+	err := f.repo.source(ctx, func(r distribution.Repository) error {
+		var err error
+		bw, err = r.Blobs(ctx).Resume(ctx, id)
+		return err
+	})
+	return bw, err
+}
+
+func (f blobMirroredBlobstore) Delete(ctx context.Context, dgst digest.Digest) error {
+	return f.repo.source(ctx, func(r distribution.Repository) error {
+		return r.Blobs(ctx).Delete(ctx, dgst)
+	})
+}
+
+// blobMirroredTags lazily accesses the source repository
+type blobMirroredTags struct {
+	repo *blobMirroredRepository
+}
+
+var _ distribution.TagService = blobMirroredTags{}
+
+func (f blobMirroredTags) Get(ctx context.Context, tag string) (distribution.Descriptor, error) {
+	var desc distribution.Descriptor
+	err := f.repo.source(ctx, func(r distribution.Repository) error {
+		var err error
+		desc, err = r.Tags(ctx).Get(ctx, tag)
+		return err
+	})
+	return desc, err
+}
+
+func (f blobMirroredTags) All(ctx context.Context) ([]string, error) {
+	var tags []string
+	err := f.repo.source(ctx, func(r distribution.Repository) error {
+		var err error
+		tags, err = r.Tags(ctx).All(ctx)
+		return err
+	})
+	return tags, err
+}
+
+func (f blobMirroredTags) Lookup(ctx context.Context, digest distribution.Descriptor) ([]string, error) {
+	var tags []string
+	err := f.repo.source(ctx, func(r distribution.Repository) error {
+		var err error
+		tags, err = r.Tags(ctx).Lookup(ctx, digest)
+		return err
+	})
+	return tags, err
+}
+
+func (f blobMirroredTags) Tag(ctx context.Context, tag string, desc distribution.Descriptor) error {
+	return f.repo.source(ctx, func(r distribution.Repository) error {
+		return r.Tags(ctx).Tag(ctx, tag, desc)
+	})
+}
+
+func (f blobMirroredTags) Untag(ctx context.Context, tag string) error {
+	return f.repo.source(ctx, func(r distribution.Repository) error {
+		return r.Tags(ctx).Untag(ctx, tag)
+	})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -430,7 +430,7 @@ github.com/openshift/client-go/user/informers/externalversions/internalinterface
 github.com/openshift/client-go/user/informers/externalversions/user
 github.com/openshift/client-go/user/informers/externalversions/user/v1
 github.com/openshift/client-go/user/listers/user/v1
-# github.com/openshift/library-go v0.0.0-20210521084623-7392ea9b02ca
+# github.com/openshift/library-go v0.0.0-20220211152057-bc7588408098
 ## explicit
 github.com/openshift/library-go/pkg/apiserver/admission/admissionregistrationtesting
 github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig


### PR DESCRIPTION
Backport of #282.

This PR bumps library-go to get a new registryclient that can correctly
handle image references like

    registry.example.com/namespace.with.dot/foo