### PR TITLE
Bug 2041133 - Fix wording in oc explain router.status.ingress.conditions

### DIFF
--- a/pkg/route/apis/route/types.go
+++ b/pkg/route/apis/route/types.go
@@ -119,7 +119,7 @@ const (
 // TODO: add LastTransitionTime, Reason, Message to match NodeCondition api.
 type RouteIngressCondition struct {
 	// Type is the type of the condition.
-	// Currently only Ready.
+	// Currently only Admitted.
 	Type RouteIngressConditionType
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.


### PR DESCRIPTION
Fixed the wording in oc explain router.status.ingress.conditions to reflect the type of "Admitted" and not "Ready".