### PR TITLE
Remove use of %w formatting directive from t.Errorf call.

### DIFF
--- a/pkg/security/apiserver/registry/podsecuritypolicyselfsubjectreview/rest_test.go
+++ b/pkg/security/apiserver/registry/podsecuritypolicyselfsubjectreview/rest_test.go
@@ -85,7 +85,7 @@ func TestPodSecurityPolicySelfSubjectReview(t *testing.T) {
 		ctx := apirequest.WithUser(apirequest.WithNamespace(apirequest.NewContext(), metav1.NamespaceDefault), &user.DefaultInfo{Name: "foo", Groups: []string{"bar", "baz"}})
 		obj, err := storage.Create(ctx, reviewRequest, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
 		if err != nil {
-			t.Errorf("%s - Unexpected error: %w", testName, err)
+			t.Errorf("%s - Unexpected error: %v", testName, err)
 			continue
 		}
 		pspssr, ok := obj.(*securityapi.PodSecurityPolicySelfSubjectReview)


### PR DESCRIPTION
The printf analyzer flags this as an error and fails to build in later
Go 1.18 releases due to this change:

https://go-review.googlesource.com/c/tools/+/340409/5/go/analysis/passes/printf/printf.go.