### PR TITLE
add retry on imagestreamtag update

### DIFF
--- a/pkg/image/apiserver/registry/imagestreamtag/imagestreamregistry_test.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/imagestreamregistry_test.go
@@ -2,6 +2,7 @@ package imagestreamtag
 
 import (
 	"context"
+	"sync/atomic"
 
 	imageapi "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/imagestream"
@@ -43,20 +44,20 @@ func NewApiResponse() ApiResponse {
 }
 
 type ApiTester struct {
-	callResponses map[int]ApiResponse
-	callCount     int
+	callResponses map[int32]ApiResponse
+	callCount     int32
 }
 
 func NewApiTester() *ApiTester {
 	tester := &ApiTester{}
 	tester.callCount = 0
-	tester.callResponses = make(map[int]ApiResponse)
+	tester.callResponses = make(map[int32]ApiResponse)
 
 	return tester
 }
 
 func (a *ApiTester) callComplete() {
-	a.callCount++
+	atomic.AddInt32(&a.callCount, 1)
 }
 
 func (r *imageStreamRegistryTester) ListImageStreams(ctx context.Context, options *metainternal.ListOptions) (*imageapi.ImageStreamList, error) {

--- a/pkg/image/apiserver/registry/imagestreamtag/imagestreamregistry_test.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/imagestreamregistry_test.go
@@ -2,12 +2,15 @@ package imagestreamtag
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 
 	imageapi "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/imagestream"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -136,4 +139,14 @@ func (r *imageStreamRegistryTester) extractImageStreamResponse(apiName string) (
 
 	return false, nil, nil
 
+}
+
+func createInvalidError() error {
+	gk := schema.GroupKind{Group: "imageregistry.operator.openshift.io", Kind: "anyKind"}
+	return errors.NewInvalid(gk, "test", nil)
+}
+
+func createConflictError() error {
+	gr := schema.GroupResource{Group: "imageregistry.operator.openshift.io", Resource: "configs"}
+	return errors.NewConflict(gr, "test", fmt.Errorf("testing error"))
 }

--- a/pkg/image/apiserver/registry/imagestreamtag/imagestreamregistry_test.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/imagestreamregistry_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-type ImageStreamRegistryTester struct {
+type imageStreamRegistryTester struct {
 	// the true implementation
 	imagestream.Registry
 
@@ -18,8 +18,8 @@ type ImageStreamRegistryTester struct {
 	registryApiTesters map[string]*ApiTester
 }
 
-func NewImageStreamRegistryTester(registry imagestream.Registry, apiTesters map[string]*ApiTester) *ImageStreamRegistryTester {
-	tester := &ImageStreamRegistryTester{}
+func NewImageStreamRegistryTester(registry imagestream.Registry, apiTesters map[string]*ApiTester) *imageStreamRegistryTester {
+	tester := &imageStreamRegistryTester{}
 
 	tester.Registry = registry
 	tester.registryApiTesters = apiTesters
@@ -29,24 +29,24 @@ func NewImageStreamRegistryTester(registry imagestream.Registry, apiTesters map[
 
 // Takes a response variable name that will be cast to the proper response type
 type ApiResponse struct {
-	response map[string] interface{}
+	response map[string]interface{}
 }
 
 func NewApiResponse() ApiResponse {
 	response := ApiResponse{}
-	response.response = make(map[string] interface{})
+	response.response = make(map[string]interface{})
 	return response
 }
 
 type ApiTester struct {
-	callResponses map[int] ApiResponse
+	callResponses map[int]ApiResponse
 	callCount     int
 }
 
 func NewApiTester() *ApiTester {
 	tester := &ApiTester{}
 	tester.callCount = 0
-	tester.callResponses = make(map[int] ApiResponse)
+	tester.callResponses = make(map[int]ApiResponse)
 
 	return tester
 }
@@ -55,15 +55,15 @@ func (a *ApiTester) callComplete() {
 	a.callCount++
 }
 
-func (r *ImageStreamRegistryTester) ListImageStreams(ctx context.Context, options *metainternal.ListOptions) (*imageapi.ImageStreamList, error) {
+func (r *imageStreamRegistryTester) ListImageStreams(ctx context.Context, options *metainternal.ListOptions) (*imageapi.ImageStreamList, error) {
 	return r.Registry.ListImageStreams(ctx, options)
 }
 
-func (r *ImageStreamRegistryTester) GetImageStream(ctx context.Context, id string, options *metav1.GetOptions) (*imageapi.ImageStream, error) {
+func (r *imageStreamRegistryTester) GetImageStream(ctx context.Context, id string, options *metav1.GetOptions) (*imageapi.ImageStream, error) {
 	return r.Registry.GetImageStream(ctx, id, options)
 }
 
-func (r *ImageStreamRegistryTester) CreateImageStream(ctx context.Context, repo *imageapi.ImageStream, options *metav1.CreateOptions) (*imageapi.ImageStream, error) {
+func (r *imageStreamRegistryTester) CreateImageStream(ctx context.Context, repo *imageapi.ImageStream, options *metav1.CreateOptions) (*imageapi.ImageStream, error) {
 
 	hasApiResponse, iStream, err := r.extractImageStreamResponse("CreateImageStream")
 
@@ -74,7 +74,7 @@ func (r *ImageStreamRegistryTester) CreateImageStream(ctx context.Context, repo 
 	return r.Registry.CreateImageStream(ctx, repo, options)
 }
 
-func (r *ImageStreamRegistryTester) UpdateImageStream(ctx context.Context, repo *imageapi.ImageStream, forceAllowCreate bool, options *metav1.UpdateOptions) (*imageapi.ImageStream, error) {
+func (r *imageStreamRegistryTester) UpdateImageStream(ctx context.Context, repo *imageapi.ImageStream, forceAllowCreate bool, options *metav1.UpdateOptions) (*imageapi.ImageStream, error) {
 
 	hasApiResponse, iStream, err := r.extractImageStreamResponse("UpdateImageStream")
 
@@ -85,23 +85,23 @@ func (r *ImageStreamRegistryTester) UpdateImageStream(ctx context.Context, repo 
 	return r.Registry.UpdateImageStream(ctx, repo, forceAllowCreate, options)
 }
 
-func (r *ImageStreamRegistryTester) UpdateImageStreamSpec(ctx context.Context, repo *imageapi.ImageStream, forceAllowCreate bool, options *metav1.UpdateOptions) (*imageapi.ImageStream, error) {
+func (r *imageStreamRegistryTester) UpdateImageStreamSpec(ctx context.Context, repo *imageapi.ImageStream, forceAllowCreate bool, options *metav1.UpdateOptions) (*imageapi.ImageStream, error) {
 	return r.Registry.UpdateImageStreamSpec(ctx, repo, forceAllowCreate, options)
 }
 
-func (r *ImageStreamRegistryTester) UpdateImageStreamStatus(ctx context.Context, repo *imageapi.ImageStream, forceAllowCreate bool, options *metav1.UpdateOptions) (*imageapi.ImageStream, error) {
+func (r *imageStreamRegistryTester) UpdateImageStreamStatus(ctx context.Context, repo *imageapi.ImageStream, forceAllowCreate bool, options *metav1.UpdateOptions) (*imageapi.ImageStream, error) {
 	return r.Registry.UpdateImageStreamStatus(ctx, repo, forceAllowCreate, options)
 }
 
-func (r *ImageStreamRegistryTester) DeleteImageStream(ctx context.Context, id string) (*metav1.Status, error) {
+func (r *imageStreamRegistryTester) DeleteImageStream(ctx context.Context, id string) (*metav1.Status, error) {
 	return r.Registry.DeleteImageStream(ctx, id)
 }
 
-func (r *ImageStreamRegistryTester) WatchImageStreams(ctx context.Context, options *metainternal.ListOptions) (watch.Interface, error) {
+func (r *imageStreamRegistryTester) WatchImageStreams(ctx context.Context, options *metainternal.ListOptions) (watch.Interface, error) {
 	return r.Registry.WatchImageStreams(ctx, options)
 }
 
-func (r *ImageStreamRegistryTester) extractImageStreamResponse(apiName string) (bool, *imageapi.ImageStream, error) {
+func (r *imageStreamRegistryTester) extractImageStreamResponse(apiName string) (bool, *imageapi.ImageStream, error) {
 
 	if apiTester, ok := r.registryApiTesters[apiName]; ok {
 

--- a/pkg/image/apiserver/registry/imagestreamtag/imagestreamregistrytester.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/imagestreamregistrytester.go
@@ -1,0 +1,131 @@
+package imagestreamtag
+
+import (
+	"context"
+
+	imageapi "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
+	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/imagestream"
+	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type ImageStreamRegistryTester struct {
+	// the true implementation
+	imagestream.Registry
+
+	// which apis are we providing responses for
+	registryApiTesters map[string]*ApiTester
+}
+
+func NewImageStreamRegistryTester(registry imagestream.Registry, apiTesters map[string]*ApiTester) *ImageStreamRegistryTester {
+	tester := &ImageStreamRegistryTester{}
+
+	tester.Registry = registry
+	tester.registryApiTesters = apiTesters
+
+	return tester
+}
+
+// Takes a response variable name that will be cast to the proper response type
+type ApiResponse struct {
+	response map[string] interface{}
+}
+
+func NewApiResponse() ApiResponse {
+	response := ApiResponse{}
+	response.response = make(map[string] interface{})
+	return response
+}
+
+type ApiTester struct {
+	callResponses map[int] ApiResponse
+	callCount     int
+}
+
+func NewApiTester() *ApiTester {
+	tester := &ApiTester{}
+	tester.callCount = 0
+	tester.callResponses = make(map[int] ApiResponse)
+
+	return tester
+}
+
+func (a *ApiTester) callComplete() {
+	a.callCount++
+}
+
+func (r *ImageStreamRegistryTester) ListImageStreams(ctx context.Context, options *metainternal.ListOptions) (*imageapi.ImageStreamList, error) {
+	return r.Registry.ListImageStreams(ctx, options)
+}
+
+func (r *ImageStreamRegistryTester) GetImageStream(ctx context.Context, id string, options *metav1.GetOptions) (*imageapi.ImageStream, error) {
+	return r.Registry.GetImageStream(ctx, id, options)
+}
+
+func (r *ImageStreamRegistryTester) CreateImageStream(ctx context.Context, repo *imageapi.ImageStream, options *metav1.CreateOptions) (*imageapi.ImageStream, error) {
+
+	hasApiResponse, iStream, err := r.extractImageStreamResponse("CreateImageStream")
+
+	if hasApiResponse {
+		return iStream, err
+	}
+
+	return r.Registry.CreateImageStream(ctx, repo, options)
+}
+
+func (r *ImageStreamRegistryTester) UpdateImageStream(ctx context.Context, repo *imageapi.ImageStream, forceAllowCreate bool, options *metav1.UpdateOptions) (*imageapi.ImageStream, error) {
+
+	hasApiResponse, iStream, err := r.extractImageStreamResponse("UpdateImageStream")
+
+	if hasApiResponse {
+		return iStream, err
+	}
+
+	return r.Registry.UpdateImageStream(ctx, repo, forceAllowCreate, options)
+}
+
+func (r *ImageStreamRegistryTester) UpdateImageStreamSpec(ctx context.Context, repo *imageapi.ImageStream, forceAllowCreate bool, options *metav1.UpdateOptions) (*imageapi.ImageStream, error) {
+	return r.Registry.UpdateImageStreamSpec(ctx, repo, forceAllowCreate, options)
+}
+
+func (r *ImageStreamRegistryTester) UpdateImageStreamStatus(ctx context.Context, repo *imageapi.ImageStream, forceAllowCreate bool, options *metav1.UpdateOptions) (*imageapi.ImageStream, error) {
+	return r.Registry.UpdateImageStreamStatus(ctx, repo, forceAllowCreate, options)
+}
+
+func (r *ImageStreamRegistryTester) DeleteImageStream(ctx context.Context, id string) (*metav1.Status, error) {
+	return r.Registry.DeleteImageStream(ctx, id)
+}
+
+func (r *ImageStreamRegistryTester) WatchImageStreams(ctx context.Context, options *metainternal.ListOptions) (watch.Interface, error) {
+	return r.Registry.WatchImageStreams(ctx, options)
+}
+
+func (r *ImageStreamRegistryTester) extractImageStreamResponse(apiName string) (bool, *imageapi.ImageStream, error) {
+
+	if apiTester, ok := r.registryApiTesters[apiName]; ok {
+
+		// increment the call count when done
+		defer apiTester.callComplete()
+
+		if responses, okResponses := apiTester.callResponses[apiTester.callCount]; okResponses {
+
+			var err error = nil
+
+			if responseErr, okResponse := responses.response["error"]; okResponse {
+				err = responseErr.(error)
+			}
+
+			if responseImageStream, okImageStream := responses.response["imageStream"]; okImageStream {
+				imageStream := responseImageStream.(imageapi.ImageStream)
+				return true, &imageStream, err
+			} else {
+				return true, nil, err
+			}
+		}
+
+	}
+
+	return false, nil, nil
+
+}

--- a/pkg/image/apiserver/registry/imagestreamtag/rest.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/rest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -206,20 +207,54 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 }
 
 func (r *REST) Update(ctx context.Context, tagName string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	name, tag, err := nameAndTag(tagName)
+	var result runtime.Object
+	var created bool
+	var updateErr error
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var canRetry bool
+		result, created, canRetry, updateErr = r.update(ctx, tagName, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+		// allow RetryOnConflict to check to see if it is conflict and try again
+		if canRetry {
+			return updateErr
+		}
+
+		// if not canRetry return nill for the error, we captured it in updateErr and will pass it back up.
+		return nil
+	})
+
+	// prefer updateErr over err
+	// but if either are non nil return error
+	if updateErr != nil {
+		return nil, false, updateErr
+	}
+
 	if err != nil {
 		return nil, false, err
+	}
+
+	return result, created, updateErr
+}
+
+// returns the new imagestream tag,
+// whether the imagestream tag was newly created,
+// if we can retry the update on conflict (we only retry if a specific resourceVersion is not specified && created is false)
+// and any error encountered during the update
+func (r *REST) update(ctx context.Context, tagName string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, bool, error) {
+	name, tag, err := nameAndTag(tagName)
+	if err != nil {
+		return nil, false, false, err
 	}
 
 	create := false
 	imageStream, err := r.imageStreamRegistry.GetImageStream(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		if !kapierrors.IsNotFound(err) {
-			return nil, false, err
+			return nil, false, false, err
 		}
 		namespace, ok := apirequest.NamespaceFrom(ctx)
 		if !ok {
-			return nil, false, kapierrors.NewBadRequest("namespace is required on ImageStreamTags")
+			return nil, false, false, kapierrors.NewBadRequest("namespace is required on ImageStreamTags")
 		}
 		imageStream = &imageapi.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
@@ -234,30 +269,33 @@ func (r *REST) Update(ctx context.Context, tagName string, objInfo rest.UpdatedO
 	// create the synthetic old istag
 	old, err := newISTag(tag, imageStream, nil, true)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
 
 	obj, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, err
 	}
 
 	istag, ok := obj.(*imageapi.ImageStreamTag)
 	if !ok {
-		return nil, false, kapierrors.NewBadRequest(fmt.Sprintf("obj is not an ImageStreamTag: %#v", obj))
+		return nil, false, false, kapierrors.NewBadRequest(fmt.Sprintf("obj is not an ImageStreamTag: %#v", obj))
 	}
 
 	// check for conflict
+	canRetry := false
 	switch {
 	case len(istag.ResourceVersion) == 0:
+		// if no resource version is provided then if we encounter an update error it is ok to fetch the updated version and retry...
+		canRetry = true
 		// should disallow blind PUT, but this was previously supported
 		istag.ResourceVersion = imageStream.ResourceVersion
 	case len(imageStream.ResourceVersion) == 0:
 		// image stream did not exist, cannot update
-		return nil, false, kapierrors.NewNotFound(imagegroup.Resource("imagestreamtags"), tagName)
+		return nil, false, false, kapierrors.NewNotFound(imagegroup.Resource("imagestreamtags"), tagName)
 	case imageStream.ResourceVersion != istag.ResourceVersion:
 		// conflicting input and output
-		return nil, false, kapierrors.NewConflict(imagegroup.Resource("imagestreamtags"), istag.Name, fmt.Errorf("another caller has updated the resource version to %s", imageStream.ResourceVersion))
+		return nil, false, false, kapierrors.NewConflict(imagegroup.Resource("imagestreamtags"), istag.Name, fmt.Errorf("another caller has updated the resource version to %s", imageStream.ResourceVersion))
 	}
 
 	// When we began returning image stream labels in 3.6, old clients that didn't need to send labels would be
@@ -268,17 +306,17 @@ func (r *REST) Update(ctx context.Context, tagName string, objInfo rest.UpdatedO
 
 	if create {
 		if err := rest.BeforeCreate(r.strategy, ctx, obj); err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
 		if err := createValidation(ctx, obj.DeepCopyObject()); err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
 	} else {
 		if err := rest.BeforeUpdate(r.strategy, ctx, obj, old); err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
 		if err := updateValidation(ctx, obj.DeepCopyObject(), old.DeepCopyObject()); err != nil {
-			return nil, false, err
+			return nil, false, false, err
 		}
 	}
 
@@ -289,7 +327,7 @@ func (r *REST) Update(ctx context.Context, tagName string, objInfo rest.UpdatedO
 	tagRef, exists := imageStream.Spec.Tags[tag]
 
 	if !exists && istag.Tag == nil {
-		return nil, false, kapierrors.NewBadRequest(fmt.Sprintf("imagestreamtag %s is not a spec tag in imagestream %s/%s, cannot be updated", tag, imageStream.Namespace, imageStream.Name))
+		return nil, false, false, kapierrors.NewBadRequest(fmt.Sprintf("imagestreamtag %s is not a spec tag in imagestream %s/%s, cannot be updated", tag, imageStream.Namespace, imageStream.Name))
 	}
 
 	// if the caller set tag, override the spec tag
@@ -308,18 +346,21 @@ func (r *REST) Update(ctx context.Context, tagName string, objInfo rest.UpdatedO
 		newImageStream, err = r.imageStreamRegistry.UpdateImageStream(ctx, imageStream, false, &metav1.UpdateOptions{})
 	}
 	if err != nil {
-		return nil, false, err
+		// return true for canRetry if we had a failure for resource versions
+		// and no resource version was passed in
+		// only support canRetry if we are updating
+		return nil, false, canRetry && !create, err
 	}
 
 	image, err := r.imageFor(ctx, tag, newImageStream)
 	if err != nil {
 		if !kapierrors.IsNotFound(err) {
-			return nil, false, err
+			return nil, false, false, err
 		}
 	}
 
 	newISTag, err := newISTag(tag, newImageStream, image, true)
-	return newISTag, !exists, err
+	return newISTag, !exists, false, err
 }
 
 // Delete removes a tag from a stream. `id` is of the format <stream name>:<tag>.

--- a/pkg/image/apiserver/registry/imagestreamtag/rest.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/rest.go
@@ -211,6 +211,10 @@ func (r *REST) Update(ctx context.Context, tagName string, objInfo rest.UpdatedO
 	var created bool
 	var updateErr error
 
+	// Given a request without a resource version, the comparable logic with a standard resource is "write this no matter what".
+	// So a client is expecting an unconditional write.  The server should provide an unconditional write  if it's able to.
+	// To handle this case we first verify that we are doing an update without a resource version specified.
+	// If so, we rely on RetryOnConflict to detect the conflict error, if any, and retry the update until successful or max attempts are exhausted
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var canRetry bool
 		result, created, canRetry, updateErr = r.update(ctx, tagName, objInfo, createValidation, updateValidation, forceAllowCreate, options)

--- a/pkg/image/apiserver/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/rest_test.go
@@ -770,7 +770,7 @@ func TestUpdateImageStreamTagMultipleConflicts(t *testing.T) {
 		errorTargetID   string
 		expectCreate    bool
 		expectNilResult bool
-	}{		
+	}{
 		"valid istag conflict error": {
 			istag: &imageapi.ImageStreamTag{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/image/apiserver/registry/imagestreamtag/rest_test.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/rest_test.go
@@ -708,7 +708,8 @@ func TestUpdateImageStreamTag(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		func() {
+		t.Run(name, func(t *testing.T) {
+
 			client, server, storage := setup(t,
 
 				func(s imagestream.Storage, status, internal rest.Updater) imagestream.Registry {
@@ -718,7 +719,7 @@ func TestUpdateImageStreamTag(t *testing.T) {
 					if tc.createUpdateConflictError || tc.createUpdateInvalidError {
 
 						apiTester := NewApiTester()
-						updateResponses := make(map[int]ApiResponse)
+						updateResponses := make(map[int32]ApiResponse)
 						apiResponse := NewApiResponse()
 
 						if tc.createUpdateConflictError {
@@ -743,7 +744,7 @@ func TestUpdateImageStreamTag(t *testing.T) {
 					if tc.createCreateConflictError || tc.createCreateInvalidError {
 
 						apiTester := NewApiTester()
-						updateResponses := make(map[int]ApiResponse)
+						updateResponses := make(map[int32]ApiResponse)
 						apiResponse := NewApiResponse()
 
 						if tc.createCreateConflictError {
@@ -852,7 +853,7 @@ func TestUpdateImageStreamTag(t *testing.T) {
 				}
 			}
 
-		}()
+		})
 	}
 }
 
@@ -995,7 +996,7 @@ func TestUpdateRetryImageStreamTag(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		func() {
+		t.Run(name, func(t *testing.T) {
 			client, server, storage := setup(t,
 
 				func(s imagestream.Storage, status, internal rest.Updater) imagestream.Registry {
@@ -1005,7 +1006,7 @@ func TestUpdateRetryImageStreamTag(t *testing.T) {
 					if tc.createUpdateConflictError || tc.createUpdateInvalidError {
 
 						apiTester := NewApiTester()
-						updateResponses := make(map[int]ApiResponse)
+						updateResponses := make(map[int32]ApiResponse)
 						apiResponse := NewApiResponse()
 
 						if tc.createUpdateConflictError {
@@ -1030,7 +1031,7 @@ func TestUpdateRetryImageStreamTag(t *testing.T) {
 					if tc.createCreateConflictError || tc.createCreateInvalidError {
 
 						apiTester := NewApiTester()
-						updateResponses := make(map[int]ApiResponse)
+						updateResponses := make(map[int32]ApiResponse)
 						apiResponse := NewApiResponse()
 
 						if tc.createCreateConflictError {
@@ -1144,6 +1145,6 @@ func TestUpdateRetryImageStreamTag(t *testing.T) {
 				}
 			}
 
-		}()
+		})
 	}
 }


### PR DESCRIPTION
Adding retry during update to address test failures

https://search.ci.openshift.org/?search=.*Operation+cannot+be+fulfilled+on+imagestreamtags.*&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.12-e2e-aws-sdn-serial/1548438013934047232

: [sig-imageregistry][Feature:ImageTriggers][Serial] ImageStream API TestImageStreamTagLifecycleHook [Suite:openshift/conformance/serial]

 Message: "Operation cannot be fulfilled on imagestreamtags.image.openshift.io \"test\": the object has been modified; please apply your changes to the latest version and try again",
 
Investigation indicated that the test was not specifying a particular resourceVersion, another call (outside the audit trail) was modifying the resource between the time is was fetched and then update called resulting in the failure.  Given that a specific resourceVersion was not provided the belief is that a retry is warranted in this case.