### PR TITLE
Bug 2111167: [release-4.11] Stop unnecessary project auth cache invalidations.

### DIFF
--- a/pkg/project/auth/cache.go
+++ b/pkg/project/auth/cache.go
@@ -375,7 +375,7 @@ func (ac *AuthorizationCache) invalidateCache() bool {
 	for _, clusterRole := range clusterRoleList {
 		temporaryVersions.Insert(clusterRole.ResourceVersion)
 	}
-	if (len(ac.clusterRoleResourceVersions) != len(temporaryVersions)) || !ac.clusterRoleResourceVersions.HasAll(temporaryVersions.List()...) {
+	if !temporaryVersions.Equal(ac.clusterRoleResourceVersions) {
 		invalidateCache = true
 		ac.clusterRoleResourceVersions = temporaryVersions
 	}
@@ -386,11 +386,11 @@ func (ac *AuthorizationCache) invalidateCache() bool {
 		return invalidateCache
 	}
 
-	temporaryVersions.Delete(temporaryVersions.List()...)
+	temporaryVersions = sets.NewString()
 	for _, clusterRoleBinding := range clusterRoleBindingList {
 		temporaryVersions.Insert(clusterRoleBinding.ResourceVersion)
 	}
-	if (len(ac.clusterBindingResourceVersions) != len(temporaryVersions)) || !ac.clusterBindingResourceVersions.HasAll(temporaryVersions.List()...) {
+	if !temporaryVersions.Equal(ac.clusterBindingResourceVersions) {
 		invalidateCache = true
 		ac.clusterBindingResourceVersions = temporaryVersions
 	}


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/openshift-apiserver/pull/295.

The project authorization cache is invalidated when either the set of
clusterrole resource versions or clusterrolebinding resource versions
has changed since the previous invalidation test. The last observed
resourceversion sets are stored in fields of the cache struct for use
on the following invocation.

After computing the resource version set for clusterroles, the same
string set is cleared and repopulated with the clusterrolebinding
resource version set. Since the set's underlying type is a reference
type (map), both the clusterrole and the clusterrolebinding saved sets
point to the same map containing only clusterrolebinding resource
versions. The effect in practice is that every tick of synchronize
involves a full cache invalidation.
