### PR TITLE
Make RequiredRouteAnnotations plugin operate on v1 routes.

### DIFF
--- a/pkg/route/apiserver/admission/requiredrouteannotations/admission_test.go
+++ b/pkg/route/apiserver/admission/requiredrouteannotations/admission_test.go
@@ -433,7 +433,7 @@ func TestValidate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			admitter := NewRequiredRouteAnnotations()
+			admitter := NewRequiredRouteAnnotations(internalToV1Route)
 			if admitter == nil {
 				t.Fatal("Unexpected error: admitter is nil")
 			}


### PR DESCRIPTION
The Route API can be provided by kube-apiserver via CRD instead of by openshift-apiserver. In order to reuse the RequiredRouteAnnotations plugin outside of openshift-apiserver, it needs to drop its dependency on the internal route types. The implementation now operates on v1 routes and expects the caller to provide a function that can convert internal routes to v1 routes if necessary.

It should be straightforward to hoist the modified plugin to a library where it can be shared between openshift-apiserver and openshift/kubernetes.