### PR TITLE
Move route host assignment code out of the route REST strategy.

### DIFF
--- a/pkg/route/apiserver/admission/routehostassignment/assignment.go
+++ b/pkg/route/apiserver/admission/routehostassignment/assignment.go
@@ -1,0 +1,194 @@
+package routehostassignment
+
+import (
+	"context"
+	"fmt"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	kvalidation "k8s.io/kubernetes/pkg/apis/core/validation"
+
+	"github.com/openshift/library-go/pkg/authorization/authorizationutil"
+	routeinternal "github.com/openshift/openshift-apiserver/pkg/route/apis/route"
+	"github.com/openshift/openshift-apiserver/pkg/route/apiserver/routeinterfaces"
+)
+
+// HostGeneratedAnnotationKey is the key for an annotation set to "true" if the route's host was generated
+const HostGeneratedAnnotationKey = "openshift.io/host.generated"
+
+// Registry is an interface for performing subject access reviews
+type SubjectAccessReviewCreator interface {
+	Create(ctx context.Context, sar *authorizationv1.SubjectAccessReview, opts metav1.CreateOptions) (*authorizationv1.SubjectAccessReview, error)
+}
+
+// AllocateHost allocates a host name ONLY if the route doesn't specify a subdomain wildcard policy and
+// the host name on the route is empty and an allocator is configured.
+// It must first allocate the shard and may return an error if shard allocation fails.
+func AllocateHost(ctx context.Context, route *routeinternal.Route, sarc SubjectAccessReviewCreator, routeAllocator routeinterfaces.RouteAllocator) field.ErrorList {
+	hostSet := len(route.Spec.Host) > 0
+	certSet := route.Spec.TLS != nil && (len(route.Spec.TLS.CACertificate) > 0 || len(route.Spec.TLS.Certificate) > 0 || len(route.Spec.TLS.DestinationCACertificate) > 0 || len(route.Spec.TLS.Key) > 0)
+	if hostSet || certSet {
+		user, ok := request.UserFrom(ctx)
+		if !ok {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("unable to verify host field can be set"))}
+		}
+		res, err := sarc.Create(
+			ctx,
+			authorizationutil.AddUserToSAR(
+				user,
+				&authorizationv1.SubjectAccessReview{
+					Spec: authorizationv1.SubjectAccessReviewSpec{
+						ResourceAttributes: &authorizationv1.ResourceAttributes{
+							Namespace:   request.NamespaceValue(ctx),
+							Verb:        "create",
+							Group:       routeinternal.GroupName,
+							Resource:    "routes",
+							Subresource: "custom-host",
+						},
+					},
+				},
+			),
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
+		}
+		if !res.Status.Allowed {
+			if hostSet {
+				return field.ErrorList{field.Forbidden(field.NewPath("spec", "host"), "you do not have permission to set the host field of the route")}
+			}
+			return field.ErrorList{field.Forbidden(field.NewPath("spec", "tls"), "you do not have permission to set certificate fields on the route")}
+		}
+	}
+
+	if route.Spec.WildcardPolicy == routeinternal.WildcardPolicySubdomain {
+		// Don't allocate a host if subdomain wildcard policy.
+		return nil
+	}
+
+	if len(route.Spec.Subdomain) == 0 && len(route.Spec.Host) == 0 && routeAllocator != nil {
+		// TODO: this does not belong here, and should be removed
+		shard, err := routeAllocator.AllocateRouterShard(route)
+		if err != nil {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("allocation error: %v for route: %#v", err, route))}
+		}
+		route.Spec.Host = routeAllocator.GenerateHostname(route, shard)
+		if route.Annotations == nil {
+			route.Annotations = map[string]string{}
+		}
+		route.Annotations[HostGeneratedAnnotationKey] = "true"
+	}
+	return nil
+}
+
+func hasCertificateInfo(tls *routeinternal.TLSConfig) bool {
+	if tls == nil {
+		return false
+	}
+	return len(tls.Certificate) > 0 ||
+		len(tls.Key) > 0 ||
+		len(tls.CACertificate) > 0 ||
+		len(tls.DestinationCACertificate) > 0
+}
+
+func certificateChangeRequiresAuth(route, older *routeinternal.Route) bool {
+	switch {
+	case route.Spec.TLS != nil && older.Spec.TLS != nil:
+		a, b := route.Spec.TLS, older.Spec.TLS
+		if !hasCertificateInfo(a) {
+			// removing certificate info is allowed
+			return false
+		}
+		return a.CACertificate != b.CACertificate ||
+			a.Certificate != b.Certificate ||
+			a.DestinationCACertificate != b.DestinationCACertificate ||
+			a.Key != b.Key
+	case route.Spec.TLS != nil:
+		// using any default certificate is allowed
+		return hasCertificateInfo(route.Spec.TLS)
+	default:
+		// all other cases we are not adding additional certificate info
+		return false
+	}
+}
+
+func ValidateHostUpdate(ctx context.Context, route, older *routeinternal.Route, sarc SubjectAccessReviewCreator) field.ErrorList {
+	hostChanged := route.Spec.Host != older.Spec.Host
+	subdomainChanged := route.Spec.Subdomain != older.Spec.Subdomain
+	certChanged := certificateChangeRequiresAuth(route, older)
+	if !hostChanged && !certChanged && !subdomainChanged {
+		return nil
+	}
+	user, ok := request.UserFrom(ctx)
+	if !ok {
+		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("unable to verify host field can be changed"))}
+	}
+	res, err := sarc.Create(
+		ctx,
+		authorizationutil.AddUserToSAR(
+			user,
+			&authorizationv1.SubjectAccessReview{
+				Spec: authorizationv1.SubjectAccessReviewSpec{
+					ResourceAttributes: &authorizationv1.ResourceAttributes{
+						Namespace:   request.NamespaceValue(ctx),
+						Verb:        "update",
+						Group:       routeinternal.GroupName,
+						Resource:    "routes",
+						Subresource: "custom-host",
+					},
+				},
+			},
+		),
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		if subdomainChanged {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "subdomain"), err)}
+		}
+		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
+	}
+	if !res.Status.Allowed {
+		if hostChanged {
+			return kvalidation.ValidateImmutableField(route.Spec.Host, older.Spec.Host, field.NewPath("spec", "host"))
+		}
+		if subdomainChanged {
+			return kvalidation.ValidateImmutableField(route.Spec.Subdomain, older.Spec.Subdomain, field.NewPath("spec", "subdomain"))
+		}
+
+		// if tls is being updated without host being updated, we check if 'create' permission exists on custom-host subresource
+		res, err := sarc.Create(
+			ctx,
+			authorizationutil.AddUserToSAR(
+				user,
+				&authorizationv1.SubjectAccessReview{
+					Spec: authorizationv1.SubjectAccessReviewSpec{
+						ResourceAttributes: &authorizationv1.ResourceAttributes{
+							Namespace:   request.NamespaceValue(ctx),
+							Verb:        "create",
+							Group:       routeinternal.GroupName,
+							Resource:    "routes",
+							Subresource: "custom-host",
+						},
+					},
+				},
+			),
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
+		}
+		if !res.Status.Allowed {
+			if route.Spec.TLS == nil || older.Spec.TLS == nil {
+				return kvalidation.ValidateImmutableField(route.Spec.TLS, older.Spec.TLS, field.NewPath("spec", "tls"))
+			}
+			errs := kvalidation.ValidateImmutableField(route.Spec.TLS.CACertificate, older.Spec.TLS.CACertificate, field.NewPath("spec", "tls", "caCertificate"))
+			errs = append(errs, kvalidation.ValidateImmutableField(route.Spec.TLS.Certificate, older.Spec.TLS.Certificate, field.NewPath("spec", "tls", "certificate"))...)
+			errs = append(errs, kvalidation.ValidateImmutableField(route.Spec.TLS.DestinationCACertificate, older.Spec.TLS.DestinationCACertificate, field.NewPath("spec", "tls", "destinationCACertificate"))...)
+			errs = append(errs, kvalidation.ValidateImmutableField(route.Spec.TLS.Key, older.Spec.TLS.Key, field.NewPath("spec", "tls", "key"))...)
+			return errs
+		}
+	}
+	return nil
+}

--- a/pkg/route/apiserver/admission/routehostassignment/assignment_test.go
+++ b/pkg/route/apiserver/admission/routehostassignment/assignment_test.go
@@ -1,0 +1,390 @@
+package routehostassignment
+
+import (
+	"context"
+	"testing"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	routeinternal "github.com/openshift/openshift-apiserver/pkg/route/apis/route"
+)
+
+type testAllocator struct {
+}
+
+func (t testAllocator) AllocateRouterShard(*routeinternal.Route) (*routeinternal.RouterShard, error) {
+	return &routeinternal.RouterShard{}, nil
+}
+func (t testAllocator) GenerateHostname(*routeinternal.Route, *routeinternal.RouterShard) string {
+	return "mygeneratedhost.com"
+}
+
+type testSAR struct {
+	allow bool
+	err   error
+	sar   *authorizationv1.SubjectAccessReview
+}
+
+func (t *testSAR) Create(_ context.Context, subjectAccessReview *authorizationv1.SubjectAccessReview, _ metav1.CreateOptions) (*authorizationv1.SubjectAccessReview, error) {
+	t.sar = subjectAccessReview
+	return &authorizationv1.SubjectAccessReview{
+		Status: authorizationv1.SubjectAccessReviewStatus{
+			Allowed: t.allow,
+		},
+	}, t.err
+}
+
+func TestHostWithWildcardPolicies(t *testing.T) {
+	ctx := request.NewContext()
+	ctx = request.WithUser(ctx, &user.DefaultInfo{Name: "bob"})
+
+	tests := []struct {
+		name          string
+		host, oldHost string
+
+		subdomain, oldSubdomain string
+
+		wildcardPolicy routeinternal.WildcardPolicyType
+		tls, oldTLS    *routeinternal.TLSConfig
+
+		expected          string
+		expectedSubdomain string
+
+		errs  int
+		allow bool
+	}{
+		{
+			name:     "no-host-empty-policy",
+			expected: "mygeneratedhost.com",
+			allow:    true,
+		},
+		{
+			name:           "no-host-nopolicy",
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			expected:       "mygeneratedhost.com",
+			allow:          true,
+		},
+		{
+			name:           "no-host-wildcard-subdomain",
+			wildcardPolicy: routeinternal.WildcardPolicySubdomain,
+			expected:       "",
+			allow:          true,
+			errs:           0,
+		},
+		{
+			name:     "host-empty-policy",
+			host:     "empty.policy.test",
+			expected: "empty.policy.test",
+			allow:    true,
+		},
+		{
+			name:           "host-no-policy",
+			host:           "no.policy.test",
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			expected:       "no.policy.test",
+			allow:          true,
+		},
+		{
+			name:           "host-wildcard-subdomain",
+			host:           "wildcard.policy.test",
+			wildcardPolicy: routeinternal.WildcardPolicySubdomain,
+			expected:       "wildcard.policy.test",
+			allow:          true,
+		},
+		{
+			name:           "custom-host-permission-denied",
+			host:           "another.test",
+			expected:       "another.test",
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-destination",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-cert",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Certificate: "a"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-ca-cert",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, CACertificate: "a"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "tls-permission-denied-key",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "no-host-but-allowed",
+			expected:       "mygeneratedhost.com",
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+		},
+		{
+			name:           "update-changed-host-denied",
+			host:           "new.host",
+			expected:       "new.host",
+			oldHost:        "original.host",
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "update-changed-host-allowed",
+			host:           "new.host",
+			expected:       "new.host",
+			oldHost:        "original.host",
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          true,
+			errs:           0,
+		},
+		{
+			name:              "update-changed-subdomain-denied",
+			subdomain:         "new.host",
+			expectedSubdomain: "new.host",
+			oldSubdomain:      "original.host",
+			wildcardPolicy:    routeinternal.WildcardPolicyNone,
+			allow:             false,
+			errs:              1,
+		},
+		{
+			name:              "update-changed-subdomain-allowed",
+			subdomain:         "new.host",
+			expectedSubdomain: "new.host",
+			oldSubdomain:      "original.host",
+			wildcardPolicy:    routeinternal.WildcardPolicyNone,
+			allow:             true,
+			errs:              0,
+		},
+		{
+			name:           "key-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "key-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Key: "b"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "certificate-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Certificate: "a"},
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Certificate: "a"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "certificate-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Certificate: "a"},
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Certificate: "b"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "ca-certificate-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, CACertificate: "a"},
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, CACertificate: "a"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "ca-certificate-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, CACertificate: "a"},
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, CACertificate: "b"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "key-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Key: "a"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "key-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Key: "a"},
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge, Key: "b"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "destination-ca-certificate-unchanged",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "destination-ca-certificate-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationReencrypt, DestinationCACertificate: "a"},
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationReencrypt, DestinationCACertificate: "b"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+		{
+			name:           "set-to-edge-changed",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge},
+			oldTLS:         nil,
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "cleared-edge",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            nil,
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationEdge},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "removed-certificate",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationReencrypt},
+			oldTLS:         &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationReencrypt, Certificate: "a"},
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           0,
+		},
+		{
+			name:           "added-certificate-and-fails",
+			host:           "host",
+			expected:       "host",
+			oldHost:        "host",
+			tls:            &routeinternal.TLSConfig{Termination: routeinternal.TLSTerminationReencrypt, Certificate: "a"},
+			oldTLS:         nil,
+			wildcardPolicy: routeinternal.WildcardPolicyNone,
+			allow:          false,
+			errs:           1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			route := &routeinternal.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:       "wildcard",
+					Name:            tc.name,
+					UID:             types.UID("wild"),
+					ResourceVersion: "1",
+				},
+				Spec: routeinternal.RouteSpec{
+					Host:           tc.host,
+					Subdomain:      tc.subdomain,
+					WildcardPolicy: tc.wildcardPolicy,
+					TLS:            tc.tls,
+					To: routeinternal.RouteTargetReference{
+						Name: "test",
+						Kind: "Service",
+					},
+				},
+			}
+
+			var errs field.ErrorList
+			if len(tc.oldHost) > 0 || len(tc.oldSubdomain) > 0 || tc.oldTLS != nil {
+				oldRoute := &routeinternal.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       "wildcard",
+						Name:            tc.name,
+						UID:             types.UID("wild"),
+						ResourceVersion: "1",
+					},
+					Spec: routeinternal.RouteSpec{
+						Host:           tc.oldHost,
+						Subdomain:      tc.oldSubdomain,
+						WildcardPolicy: tc.wildcardPolicy,
+						TLS:            tc.oldTLS,
+						To: routeinternal.RouteTargetReference{
+							Name: "test",
+							Kind: "Service",
+						},
+					},
+				}
+				errs = ValidateHostUpdate(ctx, route, oldRoute, &testSAR{allow: tc.allow})
+			} else {
+				errs = AllocateHost(ctx, route, &testSAR{allow: tc.allow}, testAllocator{})
+			}
+
+			if route.Spec.Host != tc.expected {
+				t.Fatalf("expected host %s, got %s", tc.expected, route.Spec.Host)
+			}
+			if route.Spec.Subdomain != tc.expectedSubdomain {
+				t.Fatalf("expected subdomain %s, got %s", tc.expectedSubdomain, route.Spec.Subdomain)
+			}
+			if len(errs) != tc.errs {
+				t.Fatalf("expected %d errors, got %d: %v", tc.errs, len(errs), errs)
+			}
+		})
+	}
+}

--- a/pkg/route/apiserver/registry/route/etcd/etcd_test.go
+++ b/pkg/route/apiserver/registry/route/etcd/etcd_test.go
@@ -19,7 +19,7 @@ import (
 
 	routeapi "github.com/openshift/openshift-apiserver/pkg/route/apis/route"
 	_ "github.com/openshift/openshift-apiserver/pkg/route/apis/route/install"
-	"github.com/openshift/openshift-apiserver/pkg/route/apiserver/registry/route"
+	"github.com/openshift/openshift-apiserver/pkg/route/apiserver/admission/routehostassignment"
 	"github.com/openshift/openshift-apiserver/pkg/route/apiserver/routeinterfaces"
 	"k8s.io/apiserver/pkg/registry/generic"
 )
@@ -110,7 +110,7 @@ func TestCreateWithAllocation(t *testing.T) {
 	if result.Spec.Host != "bar" {
 		t.Fatalf("unexpected route: %#v", result)
 	}
-	if v, ok := result.Annotations[route.HostGeneratedAnnotationKey]; !ok || v != "true" {
+	if v, ok := result.Annotations[routehostassignment.HostGeneratedAnnotationKey]; !ok || v != "true" {
 		t.Fatalf("unexpected route: %#v", result)
 	}
 	if !allocator.Allocate || !allocator.Generate {

--- a/pkg/route/apiserver/registry/route/strategy.go
+++ b/pkg/route/apiserver/registry/route/strategy.go
@@ -8,20 +8,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
 	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	kvalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 
-	"github.com/openshift/library-go/pkg/authorization/authorizationutil"
 	routeapi "github.com/openshift/openshift-apiserver/pkg/route/apis/route"
 	"github.com/openshift/openshift-apiserver/pkg/route/apis/route/validation"
+	"github.com/openshift/openshift-apiserver/pkg/route/apiserver/admission/routehostassignment"
 	"github.com/openshift/openshift-apiserver/pkg/route/apiserver/routeinterfaces"
 )
-
-// HostGeneratedAnnotationKey is the key for an annotation set to "true" if the route's host was generated
-const HostGeneratedAnnotationKey = "openshift.io/host.generated"
 
 // Registry is an interface for performing subject access reviews
 type SubjectAccessReviewInterface interface {
@@ -71,69 +66,9 @@ func (s routeStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Ob
 	}
 }
 
-// allocateHost allocates a host name ONLY if the route doesn't specify a subdomain wildcard policy and
-// the host name on the route is empty and an allocator is configured.
-// It must first allocate the shard and may return an error if shard allocation fails.
-func (s routeStrategy) allocateHost(ctx context.Context, route *routeapi.Route) field.ErrorList {
-	hostSet := len(route.Spec.Host) > 0
-	certSet := route.Spec.TLS != nil && (len(route.Spec.TLS.CACertificate) > 0 || len(route.Spec.TLS.Certificate) > 0 || len(route.Spec.TLS.DestinationCACertificate) > 0 || len(route.Spec.TLS.Key) > 0)
-	if hostSet || certSet {
-		user, ok := apirequest.UserFrom(ctx)
-		if !ok {
-			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("unable to verify host field can be set"))}
-		}
-		res, err := s.sarClient.Create(
-			ctx,
-			authorizationutil.AddUserToSAR(
-				user,
-				&authorizationapi.SubjectAccessReview{
-					Spec: authorizationapi.SubjectAccessReviewSpec{
-						ResourceAttributes: &authorizationapi.ResourceAttributes{
-							Namespace:   apirequest.NamespaceValue(ctx),
-							Verb:        "create",
-							Group:       routeapi.GroupName,
-							Resource:    "routes",
-							Subresource: "custom-host",
-						},
-					},
-				},
-			),
-			metav1.CreateOptions{},
-		)
-		if err != nil {
-			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
-		}
-		if !res.Status.Allowed {
-			if hostSet {
-				return field.ErrorList{field.Forbidden(field.NewPath("spec", "host"), "you do not have permission to set the host field of the route")}
-			}
-			return field.ErrorList{field.Forbidden(field.NewPath("spec", "tls"), "you do not have permission to set certificate fields on the route")}
-		}
-	}
-
-	if route.Spec.WildcardPolicy == routeapi.WildcardPolicySubdomain {
-		// Don't allocate a host if subdomain wildcard policy.
-		return nil
-	}
-
-	if len(route.Spec.Subdomain) == 0 && len(route.Spec.Host) == 0 && s.RouteAllocator != nil {
-		// TODO: this does not belong here, and should be removed
-		shard, err := s.RouteAllocator.AllocateRouterShard(route)
-		if err != nil {
-			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("allocation error: %v for route: %#v", err, route))}
-		}
-		route.Spec.Host = s.RouteAllocator.GenerateHostname(route, shard)
-		if route.Annotations == nil {
-			route.Annotations = map[string]string{}
-		}
-		route.Annotations[HostGeneratedAnnotationKey] = "true"
-	}
-	return nil
-}
-
 func (s routeStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	route := obj.(*routeapi.Route)
-	errs := s.allocateHost(ctx, route)
+	errs := routehostassignment.AllocateHost(ctx, route, s.sarClient, s.RouteAllocator)
 	errs = append(errs, validation.ValidateRoute(route)...)
 	return errs
 }
@@ -154,119 +89,9 @@ func (routeStrategy) Canonicalize(obj runtime.Object) {
 func (s routeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	oldRoute := old.(*routeapi.Route)
 	objRoute := obj.(*routeapi.Route)
-	errs := s.validateHostUpdate(ctx, objRoute, oldRoute)
+	errs := routehostassignment.ValidateHostUpdate(ctx, objRoute, oldRoute, s.sarClient)
 	errs = append(errs, validation.ValidateRouteUpdate(objRoute, oldRoute)...)
 	return errs
-}
-
-func hasCertificateInfo(tls *routeapi.TLSConfig) bool {
-	if tls == nil {
-		return false
-	}
-	return len(tls.Certificate) > 0 ||
-		len(tls.Key) > 0 ||
-		len(tls.CACertificate) > 0 ||
-		len(tls.DestinationCACertificate) > 0
-}
-
-func certificateChangeRequiresAuth(route, older *routeapi.Route) bool {
-	switch {
-	case route.Spec.TLS != nil && older.Spec.TLS != nil:
-		a, b := route.Spec.TLS, older.Spec.TLS
-		if !hasCertificateInfo(a) {
-			// removing certificate info is allowed
-			return false
-		}
-		return a.CACertificate != b.CACertificate ||
-			a.Certificate != b.Certificate ||
-			a.DestinationCACertificate != b.DestinationCACertificate ||
-			a.Key != b.Key
-	case route.Spec.TLS != nil:
-		// using any default certificate is allowed
-		return hasCertificateInfo(route.Spec.TLS)
-	default:
-		// all other cases we are not adding additional certificate info
-		return false
-	}
-}
-
-func (s routeStrategy) validateHostUpdate(ctx context.Context, route, older *routeapi.Route) field.ErrorList {
-	hostChanged := route.Spec.Host != older.Spec.Host
-	subdomainChanged := route.Spec.Subdomain != older.Spec.Subdomain
-	certChanged := certificateChangeRequiresAuth(route, older)
-	if !hostChanged && !certChanged && !subdomainChanged {
-		return nil
-	}
-	user, ok := apirequest.UserFrom(ctx)
-	if !ok {
-		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), fmt.Errorf("unable to verify host field can be changed"))}
-	}
-	res, err := s.sarClient.Create(
-		ctx,
-		authorizationutil.AddUserToSAR(
-			user,
-			&authorizationapi.SubjectAccessReview{
-				Spec: authorizationapi.SubjectAccessReviewSpec{
-					ResourceAttributes: &authorizationapi.ResourceAttributes{
-						Namespace:   apirequest.NamespaceValue(ctx),
-						Verb:        "update",
-						Group:       routeapi.GroupName,
-						Resource:    "routes",
-						Subresource: "custom-host",
-					},
-				},
-			},
-		),
-		metav1.CreateOptions{},
-	)
-	if err != nil {
-		if subdomainChanged {
-			return field.ErrorList{field.InternalError(field.NewPath("spec", "subdomain"), err)}
-		}
-		return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
-	}
-	if !res.Status.Allowed {
-		if hostChanged {
-			return kvalidation.ValidateImmutableField(route.Spec.Host, older.Spec.Host, field.NewPath("spec", "host"))
-		}
-		if subdomainChanged {
-			return kvalidation.ValidateImmutableField(route.Spec.Subdomain, older.Spec.Subdomain, field.NewPath("spec", "subdomain"))
-		}
-
-		// if tls is being updated without host being updated, we check if 'create' permission exists on custom-host subresource
-		res, err := s.sarClient.Create(
-			ctx,
-			authorizationutil.AddUserToSAR(
-				user,
-				&authorizationapi.SubjectAccessReview{
-					Spec: authorizationapi.SubjectAccessReviewSpec{
-						ResourceAttributes: &authorizationapi.ResourceAttributes{
-							Namespace:   apirequest.NamespaceValue(ctx),
-							Verb:        "create",
-							Group:       routeapi.GroupName,
-							Resource:    "routes",
-							Subresource: "custom-host",
-						},
-					},
-				},
-			),
-			metav1.CreateOptions{},
-		)
-		if err != nil {
-			return field.ErrorList{field.InternalError(field.NewPath("spec", "host"), err)}
-		}
-		if !res.Status.Allowed {
-			if route.Spec.TLS == nil || older.Spec.TLS == nil {
-				return kvalidation.ValidateImmutableField(route.Spec.TLS, older.Spec.TLS, field.NewPath("spec", "tls"))
-			}
-			errs := kvalidation.ValidateImmutableField(route.Spec.TLS.CACertificate, older.Spec.TLS.CACertificate, field.NewPath("spec", "tls", "caCertificate"))
-			errs = append(errs, kvalidation.ValidateImmutableField(route.Spec.TLS.Certificate, older.Spec.TLS.Certificate, field.NewPath("spec", "tls", "certificate"))...)
-			errs = append(errs, kvalidation.ValidateImmutableField(route.Spec.TLS.DestinationCACertificate, older.Spec.TLS.DestinationCACertificate, field.NewPath("spec", "tls", "destinationCACertificate"))...)
-			errs = append(errs, kvalidation.ValidateImmutableField(route.Spec.TLS.Key, older.Spec.TLS.Key, field.NewPath("spec", "tls", "key"))...)
-			return errs
-		}
-	}
-	return nil
 }
 
 // WarningsOnUpdate returns warnings for the given update.


### PR DESCRIPTION
The eventual goal is to handle host assignment via admission plugins in order to share one implementation between apiserver- and CRD-based routes. In this phase, the relevant functions and tests are moved with only necessary changes.