### PR TITLE
[OCPNODE-1448] idms migrations

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
@@ -248,6 +248,7 @@ func NewOpenshiftAPIConfig(config *openshiftcontrolplanev1.OpenShiftAPIServerCon
 			QuotaInformers:                     informers.quotaInformers,
 			SecurityInformers:                  informers.securityInformers,
 			OperatorInformers:                  informers.operatorInformers,
+			ConfigInformers:                    informers.configInformers,
 			RuleResolver:                       ruleResolver,
 			SubjectLocator:                     subjectLocator,
 			RegistryHostnameRetriever:          registryHostnameRetriever,

--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/openshift_apiserver.go
@@ -32,6 +32,7 @@ import (
 	rbacauthorizer "k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
 	openshiftcontrolplanev1 "github.com/openshift/api/openshiftcontrolplane/v1"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
 	quotainformer "github.com/openshift/client-go/quota/informers/externalversions"
 	securityv1informer "github.com/openshift/client-go/security/informers/externalversions"
@@ -67,6 +68,7 @@ type OpenshiftAPIExtraConfig struct {
 	QuotaInformers    quotainformer.SharedInformerFactory
 	SecurityInformers securityv1informer.SharedInformerFactory
 	OperatorInformers operatorinformers.SharedInformerFactory
+	ConfigInformers   configinformers.SharedInformerFactory
 
 	// these are all required to build our storage
 	RuleResolver   rbacregistryvalidation.AuthorizationRuleResolver
@@ -106,6 +108,9 @@ func (c *OpenshiftAPIExtraConfig) Validate() error {
 	}
 	if c.OperatorInformers == nil {
 		ret = append(ret, fmt.Errorf("OperatorInformers is required"))
+	}
+	if c.ConfigInformers == nil {
+		ret = append(ret, fmt.Errorf("ConfigInformers is required"))
 	}
 	if c.RuleResolver == nil {
 		ret = append(ret, fmt.Errorf("RuleResolver is required"))
@@ -241,6 +246,7 @@ func (c *completedConfig) withImageAPIServer(delegateAPIServer genericapiserver.
 			Scheme:                             legacyscheme.Scheme,
 			AdditionalTrustedCA:                c.ExtraConfig.AdditionalTrustedCA,
 			OperatorInformers:                  c.ExtraConfig.OperatorInformers,
+			ConfigInformers:                    c.ExtraConfig.ConfigInformers,
 		},
 	}
 	// server is required to install OpenAPI to register and serve openapi spec for its types

--- a/pkg/image/apiserver/apiserver.go
+++ b/pkg/image/apiserver/apiserver.go
@@ -28,6 +28,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 	openshiftcontrolplanev1 "github.com/openshift/api/openshiftcontrolplane/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	imagev1client "github.com/openshift/client-go/image/clientset/versioned"
 	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
 	"github.com/openshift/openshift-apiserver/pkg/image/apis/image/validation/whitelist"
@@ -54,6 +55,7 @@ type ExtraConfig struct {
 	MaxImagesBulkImportedPerRepository int
 	AdditionalTrustedCA                []byte
 	OperatorInformers                  operatorinformers.SharedInformerFactory
+	ConfigInformers                    configinformers.SharedInformerFactory
 
 	// TODO these should all become local eventually
 	Scheme *runtime.Scheme
@@ -277,6 +279,8 @@ func (c *completedConfig) newV1RESTStorage() (map[string]rest.Storage, error) {
 		whitelister,
 		authorizationClient.SubjectAccessReviews(),
 		c.ExtraConfig.OperatorInformers.Operator().V1alpha1().ImageContentSourcePolicies().Lister(),
+		c.ExtraConfig.ConfigInformers.Config().V1().ImageDigestMirrorSets().Lister(),
+		c.ExtraConfig.ConfigInformers.Config().V1().ImageTagMirrorSets().Lister(),
 		configV1Client.ConfigV1(),
 	)
 	imageStreamImageStorage := imagestreamimage.NewREST(imageRegistry, imageStreamRegistry)


### PR DESCRIPTION
story card: [OCPNODE-1448](https://issues.redhat.com/browse/OCPNODE-1448)
This PR is a part of code migration to use ImageDigestMirrorSet API. 
The [OCPNODE-521](https://issues.redhat.com//browse/OCPNODE-521) will land new CRDs for image mirror configurations 4.13.
    The current components rely on ICSP and should use new APIs in future release.
- Epic to keep track of ICSP migrations for openshift components: https://issues.redhat.com/browse/OCPNODE-1258    
- ImageDigestMirrorSet implemented: openshift/machine-config-operator#3037 
- ImageDigestMirrorSet epic: https://issues.redhat.com/browse/OCPNODE-521