### PR TITLE
wip: project auth cache watcher deadlock

### DIFF
--- a/pkg/project/auth/cache.go
+++ b/pkg/project/auth/cache.go
@@ -608,8 +608,11 @@ func addSubjectsToNamespace(subjectRecordStore cache.Store, subjects []string, n
 
 func (ac *AuthorizationCache) notifyWatchers(namespace string, exists *reviewRecord, users, groups sets.String) {
 	ac.watcherLock.Lock()
-	defer ac.watcherLock.Unlock()
-	for _, watcher := range ac.watchers {
+	watchers := make([]CacheWatcher, len(ac.watchers))
+	copy(watchers, ac.watchers)
+	ac.watcherLock.Unlock()
+
+	for _, watcher := range watchers {
 		watcher.GroupMembershipChanged(namespace, users, groups)
 	}
 }


### PR DESCRIPTION
During project auth cache invalidation, while holding ac.lock:
https://github.com/openshift/openshift-apiserver/blob/03d074ad2d24d4d4f2903b6fe78be24cae60057a/pkg/project/auth/cache.go#L415
GroupMembershipChanged is called on all watchers while holding ac.watcherLock:
https://github.com/openshift/openshift-apiserver/blob/a3c91dc1d1236aff51e23eb12586e6cc393606e2/pkg/project/auth/cache.go#L610-L614
in turn, the watcher implementation may call RemoveWatcher on the cache:
https://github.com/openshift/openshift-apiserver/blob/a3c91dc1d1236aff51e23eb12586e6cc393606e2/pkg/project/auth/watch.go#L144
which requires the same lock:
https://github.com/openshift/openshift-apiserver/blob/a3c91dc1d1236aff51e23eb12586e6cc393606e2/pkg/project/auth/cache.go#L269


The project proxy needs to acquire the same lock in the course of servicing List requests:
https://github.com/openshift/openshift-apiserver/blob/03d074ad2d24d4d4f2903b6fe78be24cae60057a/pkg/project/apiserver/registry/project/proxy/proxy.go#L89
https://github.com/openshift/openshift-apiserver/blob/03d074ad2d24d4d4f2903b6fe78be24cae60057a/pkg/project/auth/cache.go#L486



