### PR TITLE
OCPBUGS-2803: Revert "projects: add rw mutex to auth cache"

### DIFF
--- a/pkg/project/auth/cache.go
+++ b/pkg/project/auth/cache.go
@@ -169,8 +169,6 @@ func (l syncedClusterRoleBindingLister) LastSyncResourceVersion() string {
 
 // AuthorizationCache maintains a cache on the set of namespaces a user or group can access.
 type AuthorizationCache struct {
-	lock sync.RWMutex
-
 	// allKnownNamespaces we track all the known namespaces, so we can detect deletes.
 	// TODO remove this in favor of a list/watch mechanism for projects
 	allKnownNamespaces        sets.String
@@ -410,11 +408,6 @@ func (ac *AuthorizationCache) synchronize() {
 	groupSubjectRecordStore := ac.groupSubjectRecordStore
 	reviewRecordStore := ac.reviewRecordStore
 
-	// from here on we must be the only writer to the cache
-	// Note: even the invalidateCache() func has side-effects on ac
-	ac.lock.Lock()
-	defer ac.lock.Unlock()
-
 	// if there was a global change that forced complete invalidation, we rebuild our cache and do a fast swap at end
 	invalidateCache := ac.invalidateCache()
 	if invalidateCache {
@@ -483,9 +476,6 @@ func (ac *AuthorizationCache) syncRequest(request *reviewRequest, userSubjectRec
 
 // List returns the set of namespace names the user has access to view
 func (ac *AuthorizationCache) List(userInfo user.Info, selector labels.Selector) (*corev1.NamespaceList, error) {
-	ac.lock.RLock()
-	defer ac.lock.RUnlock()
-
 	keys := sets.String{}
 	user := userInfo.GetName()
 	groups := userInfo.GetGroups()
@@ -530,9 +520,6 @@ func (ac *AuthorizationCache) List(userInfo user.Info, selector labels.Selector)
 }
 
 func (ac *AuthorizationCache) ReadyForAccess() bool {
-	ac.lock.RLock()
-	defer ac.lock.RUnlock()
-
 	return len(ac.lastState) > 0
 }
 


### PR DESCRIPTION
This reverts commit a0312dfd20d114fd36af80196c1873389530e784.

Clusters with high namespace and RBAC counts exhibit very long (~minutes) project auth cache sync times. On such clusters, project list requests are effectively unavailable due to time spent waiting to acquire the project auth cache lock.

```
goroutine 9646202 [semacquire, 3 minutes]:
sync.runtime_SemacquireMutex(0x0?, 0x98?, 0xc0097c7260?)
	runtime/sema.go:71 +0x25
sync.(*RWMutex).RLock(...)
	sync/rwmutex.go:63
github.com/openshift/openshift-apiserver/pkg/project/auth.(*AuthorizationCache).List(0xc000437040, {0x47c9070, 0xc02cdc4c40}, {0x47cf848, 0x639d800})
	github.com/openshift/openshift-apiserver/pkg/project/auth/cache.go:486 +0x9a
github.com/openshift/openshift-apiserver/pkg/project/apiserver/registry/project/proxy.(*REST).List(0xc000ed97a0, {0x47c8238?, 0xc026791c80?}, 0xc020328b40)
--
goroutine 9630287 [semacquire, 3 minutes]:
sync.runtime_SemacquireMutex(0x0?, 0x50?, 0xc01ceaa468?)
	runtime/sema.go:71 +0x25
sync.(*RWMutex).RLock(...)
	sync/rwmutex.go:63
github.com/openshift/openshift-apiserver/pkg/project/auth.(*AuthorizationCache).List(0xc000437040, {0x47c9070, 0xc0386c8240}, {0x47cf848, 0x639d800})
	github.com/openshift/openshift-apiserver/pkg/project/auth/cache.go:486 +0x9a
github.com/openshift/openshift-apiserver/pkg/project/apiserver/registry/project/proxy.(*REST).List(0xc000ed97a0, {0x47c8238?, 0xc03198b140?}, 0xc0203b26c0)
--
goroutine 9641573 [semacquire, 4 minutes]:
sync.runtime_SemacquireMutex(0x6c6f736e6f632d74?, 0x65?, 0x2f73676e69747465?)
	runtime/sema.go:71 +0x25
sync.(*RWMutex).RLock(...)
	sync/rwmutex.go:63
github.com/openshift/openshift-apiserver/pkg/project/auth.(*AuthorizationCache).List(0xc000437040, {0x47c9070, 0xc019f7f740}, {0x47cf848, 0xc01c9c0c78})
	github.com/openshift/openshift-apiserver/pkg/project/auth/cache.go:486 +0x9a
github.com/openshift/openshift-apiserver/pkg/project/auth.NewUserProjectWatcher({0x47c9070?, 0xc019f7f740}, 0xc01cbc67b0, 0xc0005e0b80, {0x47a7d58, 0xc000437040}, 0x0, {{0x47cf848, 0x639d800}, {0x47cf7f8, ...}, ...})
```