### PR TITLE
[release-4.11] OCPBUGS-2809: Revert "projects: add rw mutex to auth cache"

### DIFF
--- a/pkg/project/auth/cache.go
+++ b/pkg/project/auth/cache.go
@@ -169,8 +169,6 @@ func (l syncedClusterRoleBindingLister) LastSyncResourceVersion() string {
 
 // AuthorizationCache maintains a cache on the set of namespaces a user or group can access.
 type AuthorizationCache struct {
-	lock sync.RWMutex
-
 	// allKnownNamespaces we track all the known namespaces, so we can detect deletes.
 	// TODO remove this in favor of a list/watch mechanism for projects
 	allKnownNamespaces        sets.String
@@ -410,11 +408,6 @@ func (ac *AuthorizationCache) synchronize() {
 	groupSubjectRecordStore := ac.groupSubjectRecordStore
 	reviewRecordStore := ac.reviewRecordStore
 
-	// from here on we must be the only writer to the cache
-	// Note: even the invalidateCache() func has side-effects on ac
-	ac.lock.Lock()
-	defer ac.lock.Unlock()
-
 	// if there was a global change that forced complete invalidation, we rebuild our cache and do a fast swap at end
 	invalidateCache := ac.invalidateCache()
 	if invalidateCache {
@@ -483,9 +476,6 @@ func (ac *AuthorizationCache) syncRequest(request *reviewRequest, userSubjectRec
 
 // List returns the set of namespace names the user has access to view
 func (ac *AuthorizationCache) List(userInfo user.Info, selector labels.Selector) (*corev1.NamespaceList, error) {
-	ac.lock.RLock()
-	defer ac.lock.RUnlock()
-
 	keys := sets.String{}
 	user := userInfo.GetName()
 	groups := userInfo.GetGroups()
@@ -530,9 +520,6 @@ func (ac *AuthorizationCache) List(userInfo user.Info, selector labels.Selector)
 }
 
 func (ac *AuthorizationCache) ReadyForAccess() bool {
-	ac.lock.RLock()
-	defer ac.lock.RUnlock()
-
 	return len(ac.lastState) > 0
 }
 

--- a/pkg/project/auth/cache_test.go
+++ b/pkg/project/auth/cache_test.go
@@ -1,17 +1,14 @@
 package auth
 
 import (
-	"context"
 	"fmt"
 	"strconv"
-	"sync"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -177,54 +174,4 @@ func TestSyncNamespace(t *testing.T) {
 	validateList(t, authorizationCache, bob, sets.NewString("foo", "bar", "car"))
 	validateList(t, authorizationCache, eve, sets.NewString("bar", "car"))
 	validateList(t, authorizationCache, frank, sets.NewString())
-}
-
-func TestRaces(t *testing.T) {
-	namespaceList := corev1.NamespaceList{}
-	mockKubeClient := fake.NewSimpleClientset(&namespaceList)
-
-	informers := informers.NewSharedInformerFactory(mockKubeClient, controller.NoResyncPeriodFunc())
-	nsIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	nsLister := corev1listers.NewNamespaceLister(nsIndexer)
-
-	authorizationCache := NewAuthorizationCache(
-		nsLister,
-		informers.Core().V1().Namespaces().Informer(),
-		&alwaysAcceptReviewer{},
-		informers.Rbac().V1(),
-	)
-	authorizationCache.skip = &neverSkipSynchronizer{}
-
-	// synchronize the cache continuously
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		i := 0
-		wait.UntilWithContext(ctx, func(ctx context.Context) {
-			nsIndexer.Add(&corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("foo%d", i), ResourceVersion: fmt.Sprintf("%d", i)},
-			})
-			i++
-			authorizationCache.synchronize()
-		}, 0)
-	}()
-
-	var wg sync.WaitGroup
-	for i := 0; i < 1000; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			authorizationCache.List(alice, labels.Everything())
-		}()
-	}
-	wg.Wait()
-}
-
-type alwaysAcceptReviewer struct{}
-
-func (r *alwaysAcceptReviewer) Review(name string) (Review, error) {
-	return &mockReview{
-		users:  []string{alice.GetName()},
-		groups: alice.GetGroups(),
-	}, nil
 }


### PR DESCRIPTION
Backport of https://github.com/openshift/openshift-apiserver/pull/326 to 4.11.

This reverts commit a0312dfd20d114fd36af80196c1873389530e784.

Clusters with high namespace and RBAC counts exhibit very long (~minutes) project auth cache sync times. On such clusters, project list requests are effectively unavailable due to time spent waiting to acquire the project auth cache lock.