### PR TITLE
move the deployer role and binding to the ocm-o

### DIFF
--- a/pkg/bootstrappolicy/controller_policy.go
+++ b/pkg/bootstrappolicy/controller_policy.go
@@ -346,7 +346,6 @@ func init() {
 	// the controller needs to be bound to the roles it is going to try to create
 	bindControllerRole(InfraDefaultRoleBindingsControllerServiceAccountName, ImagePullerRoleName)
 	bindControllerRole(InfraDefaultRoleBindingsControllerServiceAccountName, ImageBuilderRoleName)
-	bindControllerRole(InfraDefaultRoleBindingsControllerServiceAccountName, DeployerRoleName)
 	addControllerRole(rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + InfraDefaultRoleBindingsControllerServiceAccountName},
 		Rules: []rbacv1.PolicyRule{

--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -582,27 +582,6 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: DeployerRoleName,
-				Annotations: map[string]string{
-					openShiftDescription: "Grants the right to deploy within a project.  Used primarily with service accounts for automated deployments.",
-				},
-			},
-			Rules: []rbacv1.PolicyRule{
-				// "delete" is required here for compatibility with older deployer images
-				// (see https://github.com/openshift/origin/pull/14322#issuecomment-303968976)
-				// TODO: remove "delete" rule few releases after 3.6
-				rbacv1helpers.NewRule("delete").Groups(kapiGroup).Resources("replicationcontrollers").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "list", "watch", "update").Groups(kapiGroup).Resources("replicationcontrollers").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "update").Groups(kapiGroup).Resources("replicationcontrollers/scale").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "list", "watch", "create").Groups(kapiGroup).Resources("pods").RuleOrDie(),
-				rbacv1helpers.NewRule("get").Groups(kapiGroup).Resources("pods/log").RuleOrDie(),
-				rbacv1helpers.NewRule("create", "list").Groups(kapiGroup).Resources("events").RuleOrDie(),
-
-				rbacv1helpers.NewRule("create", "update").Groups(imageGroup, legacyImageGroup).Resources("imagestreamtags", "imagetags").RuleOrDie(),
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
 				Name: MasterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -654,21 +654,6 @@ items:
     annotations:
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
-    name: system:deployer
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: system:deployer
-  subjects:
-  - kind: ServiceAccount
-    name: default-rolebindings-controller
-    namespace: openshift-infra
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRoleBinding
-  metadata:
-    annotations:
-      rbac.authorization.kubernetes.io/autoupdate: "true"
-    creationTimestamp: null
     name: system:openshift:controller:default-rolebindings-controller
   roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_roles.yaml
@@ -1593,69 +1593,6 @@ items:
   kind: ClusterRole
   metadata:
     annotations:
-      openshift.io/description: Grants the right to deploy within a project.  Used
-        primarily with service accounts for automated deployments.
-      rbac.authorization.kubernetes.io/autoupdate: "true"
-    creationTimestamp: null
-    name: system:deployer
-  rules:
-  - apiGroups:
-    - ""
-    resources:
-    - replicationcontrollers
-    verbs:
-    - delete
-  - apiGroups:
-    - ""
-    resources:
-    - replicationcontrollers
-    verbs:
-    - get
-    - list
-    - update
-    - watch
-  - apiGroups:
-    - ""
-    resources:
-    - replicationcontrollers/scale
-    verbs:
-    - get
-    - update
-  - apiGroups:
-    - ""
-    resources:
-    - pods
-    verbs:
-    - create
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    resources:
-    - pods/log
-    verbs:
-    - get
-  - apiGroups:
-    - ""
-    resources:
-    - events
-    verbs:
-    - create
-    - list
-  - apiGroups:
-    - ""
-    - image.openshift.io
-    resources:
-    - imagestreamtags
-    - imagetags
-    verbs:
-    - create
-    - update
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: ClusterRole
-  metadata:
-    annotations:
       rbac.authorization.kubernetes.io/autoupdate: "true"
     creationTimestamp: null
     name: system:master


### PR DESCRIPTION
after https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/270 merges, this will remove the old so we don't end up with conflict content.