### PR TITLE
OCPBUGS-7689: Fix a project validation error due to empty string value

### DIFF
--- a/pkg/project/apis/project/validation/validation.go
+++ b/pkg/project/apis/project/validation/validation.go
@@ -80,9 +80,10 @@ func ValidateProjectUpdate(newProject *projectapi.Project, oldProject *projectap
 		}
 	}
 
+	// Check to ensure no new labels are added or existing one being deleted or modified
 	for name, value := range newProject.Labels {
-		if value != oldProject.Labels[name] {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "labels").Key(name), value, "field is immutable, , try updating the namespace"))
+		if oldValue, ok := oldProject.Labels[name]; !ok || oldValue != value {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "labels").Key(name), value, "field is immutable, try updating the namespace"))
 		}
 	}
 	for name, value := range oldProject.Labels {

--- a/pkg/project/apis/project/validation/validation_test.go
+++ b/pkg/project/apis/project/validation/validation_test.go
@@ -314,7 +314,7 @@ func TestValidateProjectUpdate(t *testing.T) {
 			T: field.ErrorTypeInvalid,
 			F: "metadata.annotations[openshift.io/node-selector]",
 		},
-		"updating label": {
+		"modifying label": {
 			A: projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "project-name",
@@ -325,6 +325,30 @@ func TestValidateProjectUpdate(t *testing.T) {
 			},
 			T: field.ErrorTypeInvalid,
 			F: "metadata.labels[label-name]",
+		},
+		"adding label with empty value": {
+			A: projectapi.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "project-name",
+					ResourceVersion: "1",
+					Annotations:     project.Annotations,
+					Labels:          map[string]string{"label-name": "value", "label-test": ""},
+				},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "metadata.labels[label-test]",
+		},
+		"adding label with non-empty value": {
+			A: projectapi.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "project-name",
+					ResourceVersion: "1",
+					Annotations:     project.Annotations,
+					Labels:          map[string]string{"label-name": "value", "label-test": "test"},
+				},
+			},
+			T: field.ErrorTypeInvalid,
+			F: "metadata.labels[label-test]",
 		},
 		"deleting label": {
 			A: projectapi.Project{


### PR DESCRIPTION
When a new label with non-empty value is added to a project, validation error will occur due to missing label is mistaken as a label with empty string value.

The fix is to verify if the label exists before comparing its value.

Signed-off-by: Vu Dinh <vudinh@outlook.com>