### PR TITLE
BUILD-558: Binary Build Input for Custom Strategy

### DIFF
--- a/pkg/build/apiserver/registry/buildconfiginstantiate/rest.go
+++ b/pkg/build/apiserver/registry/buildconfiginstantiate/rest.go
@@ -289,11 +289,6 @@ func (h *binaryInstantiateHandler) handle(r io.Reader) (runtime.Object, error) {
 		Stdin:     true,
 		Container: apiserverbuildutil.GitCloneContainer,
 	}
-	// Custom builds don't have a gitclone container, so we inject the source
-	// directly into the main container.
-	if build.Spec.Strategy.CustomStrategy != nil {
-		opts.Container = apiserverbuildutil.CustomBuild
-	}
 
 	restClient, err := restclient.RESTClientFor(h.r.ClientConfig)
 	if err != nil {


### PR DESCRIPTION
Binary Inputs
-------------

Following the [openshift-apiserver #252][ocmPR] ([BUILD-558](https://issues.redhat.com//browse/BUILD-558)) modifications, which adds a regular `git-clone` init-container to the  Custom strategy Build, means the `openshift-apiserver` can follow the regular approach to stream binary inputs to a Custom build.

# Testing

This PR depedens on the [OCM changes][ocmPR], but once in place you can create the following Buildpacks based Build:

```yaml
---
kind: BuildConfig
apiVersion: build.openshift.io/v1
metadata: {}
spec:
  mountTrustedCA: true
  source:
    type: Git
    git:
      ref: main
      uri: https://github.com/otaviof/nodejs-ex.git
  strategy:
    type: Custom
    customStrategy:
      from:
        kind: DockerImage
        name: ghcr.io/otaviof/os-custom-paketo-builder:latest
      env:
        - name: BUILD_PRIVILEGED
          value: "false"
        - name: CNB_PLATFORM_API
          value: "0.10"
  output:
    to:
      kind: ImageStreamTag
      name: nodejs-ex:latest
    pushSecret:
      name: imagestreams
```

And rely on the binary inputs as usual. For that clone the example project (Node.js) and `cd` into the repository directory, i.e.:

```bash
git clone https://github.com/otaviof/nodejs-ex.git && \
  cd nodejs-ex
```

Once you have the repository clone in place, rinse-and-repeat local changes using binary inputs to build a container image for you:

```bash
oc start-build nodejs-ex --from-dir="." --follow --wait
```

[ocmPR]: https://github.com/openshift/openshift-controller-manager/pull/252