### PR TITLE
[release-4.14] OCPBUGS-11550: AUTH: update cluster-reader to include k8s.ovn.org

### DIFF
--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -51,6 +51,7 @@ var (
 	coordinationGroup          = coordination.GroupName
 	extensionsGroup            = extensions.GroupName
 	networkingGroup            = "networking.k8s.io"
+	networkingOVNGroup         = "k8s.ovn.org"
 	nodeGroup                  = "node.k8s.io"
 	policyGroup                = policy.GroupName
 	rbacGroup                  = rbac.GroupName
@@ -216,6 +217,8 @@ func GetOpenshiftBootstrapClusterRoles() []rbacv1.ClusterRole {
 
 				rbacv1helpers.NewRule(read...).Groups(networkGroup, legacyNetworkGroup).Resources("clusternetworks", "egressnetworkpolicies", "hostsubnets",
 					"netnamespaces").RuleOrDie(),
+
+				rbacv1helpers.NewRule(read...).Groups(networkingOVNGroup).Resources("egressfirewalls", "egressips", "egressqoses").RuleOrDie(),
 
 				rbacv1helpers.NewRule(read...).Groups(securityGroup, legacySecurityGroup).Resources("securitycontextconstraints").RuleOrDie(),
 				rbacv1helpers.NewRule(read...).Groups(securityGroup).Resources("rangeallocations").RuleOrDie(),


### PR DESCRIPTION
API group "k8s.ovn.org" should be included to cluster-reader role. That group has the following resources:

    - EgressFirewall
    - EgressIP
    - EgressQoS