### PR TITLE
WRKLDS-728: Disable apiservers

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
@@ -261,6 +261,7 @@ func NewOpenshiftAPIConfig(config *openshiftcontrolplanev1.OpenShiftAPIServerCon
 			ProjectRequestMessage:              config.ProjectConfig.ProjectRequestMessage,
 			ClusterQuotaMappingController:      clusterQuotaMappingController,
 			RESTMapper:                         restMapper,
+			APIServers:                         config.APIServers,
 		},
 	}
 


### PR DESCRIPTION
Extend the OA init code to explicitly disable individual apiservers. The change is important for explicitly disabling DeploymentConfigs and Builds API through capabilities. The controlplane configuration on-disk data type gets rendered by OA operator in https://github.com/openshift/cluster-openshift-apiserver-operator/pull/532.