### PR TITLE
[WIP] Remove system:unauthenticated apiGroup for system:webhook ClusterRole

### DIFF
--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -192,9 +192,6 @@ items:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: system:authenticated
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:unauthenticated
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OCPBUGS-12365

Removing the system:unauthenticated apiGroup in system:webhook ClusterRoleBinding as the system:unauthenticated user group allows unauthenticated users to get and create buildconfigs/webhooks