### PR TITLE
OCPBUGS-11393: Bump openshift/api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jteeuwen/go-bindata v3.0.8-0.20151023091102-a0ff2567cfb7+incompatible
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198
-	github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183
+	github.com/openshift/api v0.0.0-20230509100629-894b49f57a15
 	github.com/openshift/apiserver-library-go v0.0.0-20230503174907-d9b2bf6185e9
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb

--- a/go.sum
+++ b/go.sum
@@ -971,8 +971,8 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.10.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183 h1:t/CahSnpqY46sQR01SoS+Jt0jtjgmhgE6lFmRnO4q70=
-github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183/go.mod h1:4VWG+W22wrB4HfBL88P40DxLEpSOaiBVxUnfalfJo9k=
+github.com/openshift/api v0.0.0-20230509100629-894b49f57a15 h1:0aKQixYOtjKB3NKhNzFeQ1t0oDOkacpaAN1ztfZufB8=
+github.com/openshift/api v0.0.0-20230509100629-894b49f57a15/go.mod h1:4VWG+W22wrB4HfBL88P40DxLEpSOaiBVxUnfalfJo9k=
 github.com/openshift/apiserver-library-go v0.0.0-20230503174907-d9b2bf6185e9 h1:7SNTyJ2LGSrPzybeL7z08e5bSY921Cm0R6/cjtZEYJw=
 github.com/openshift/apiserver-library-go v0.0.0-20230503174907-d9b2bf6185e9/go.mod h1:pyUSwoDce710NhzXOmooyt5DBJjUEb2fifFSdKCcMyA=
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR4ah7FfaPR1WePizm0jlrsbmPu91xQZnAsVVreQV1k=

--- a/vendor/github.com/openshift/api/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
@@ -268,6 +268,10 @@ spec:
                               format: int32
                               default: 50
                               minimum: 1
+                            maxLogFiles:
+                              description: 'maxLogFiles specifies the maximum number of ACL_audit log files that can be present. Default: 5'
+                              type: integer
+                              format: int32
                             rateLimit:
                               description: rateLimit is the approximate maximum number of messages to generate per-second per-node. If unset the default of 20 msg/sec is used.
                               type: integer

--- a/vendor/github.com/openshift/api/operator/v1/types_network.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_network.go
@@ -543,6 +543,11 @@ type PolicyAuditConfig struct {
 	// +optional
 	MaxFileSize *uint32 `json:"maxFileSize,omitempty"`
 
+	// maxLogFiles specifies the maximum number of ACL_audit log files that can be present.
+	// Default: 5
+	// +optional
+	MaxLogFiles *int32 `json:"maxLogFiles,omitempty"`
+
 	// destination is the location for policy log messages.
 	// Regardless of this config, persistent logs will always be dumped to the host
 	// at /var/log/ovn/ however

--- a/vendor/github.com/openshift/api/operator/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/api/operator/v1/zz_generated.deepcopy.go
@@ -3512,6 +3512,11 @@ func (in *PolicyAuditConfig) DeepCopyInto(out *PolicyAuditConfig) {
 		*out = new(uint32)
 		**out = **in
 	}
+	if in.MaxLogFiles != nil {
+		in, out := &in.MaxLogFiles, &out.MaxLogFiles
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1423,6 +1423,7 @@ func (OpenShiftSDNConfig) SwaggerDoc() map[string]string {
 var map_PolicyAuditConfig = map[string]string{
 	"rateLimit":      "rateLimit is the approximate maximum number of messages to generate per-second per-node. If unset the default of 20 msg/sec is used.",
 	"maxFileSize":    "maxFilesSize is the max size an ACL_audit log file is allowed to reach before rotation occurs Units are in MB and the Default is 50MB",
+	"maxLogFiles":    "maxLogFiles specifies the maximum number of ACL_audit log files that can be present. Default: 5",
 	"destination":    "destination is the location for policy log messages. Regardless of this config, persistent logs will always be dumped to the host at /var/log/ovn/ however Additionally syslog output may be configured as follows. Valid values are: - \"libc\" -> to use the libc syslog() function of the host node's journdald process - \"udp:host:port\" -> for sending syslog over UDP - \"unix:file\" -> for using the UNIX domain socket directly - \"null\" -> to discard all messages logged to syslog The default is \"null\"",
 	"syslogFacility": "syslogFacility the RFC5424 facility for generated messages, e.g. \"kern\". Default is \"local0\"",
 }

--- a/vendor/github.com/openshift/api/route/v1/generated.proto
+++ b/vendor/github.com/openshift/api/route/v1/generated.proto
@@ -242,6 +242,8 @@ message RouterShard {
 }
 
 // TLSConfig defines config used to secure a route and provide termination
+//
+// +kubebuilder:validation:XValidation:rule="has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination=='passthrough') && (self.insecureEdgeTerminationPolicy=='Allow')) : true", message="cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow"
 message TLSConfig {
   // termination indicates termination type.
   //
@@ -272,9 +274,11 @@ message TLSConfig {
   // insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While
   // each router may make its own decisions on which ports to expose, this is normally port 80.
   //
-  // * Allow - traffic is sent to the server on the insecure port (default)
-  // * Disable - no traffic is allowed on the insecure port.
+  // * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default).
+  // * None - no traffic is allowed on the insecure port.
   // * Redirect - clients are redirected to the secure port.
+  //
+  // +kubebuilder:validation:Enum=Allow;None;Redirect;""
   optional string insecureEdgeTerminationPolicy = 6;
 }
 

--- a/vendor/github.com/openshift/api/route/v1/route.crd.yaml
+++ b/vendor/github.com/openshift/api/route/v1/route.crd.yaml
@@ -151,32 +151,6 @@ spec:
                               termination:
                                 enum:
                                   - edge
-                    - anyOf:
-                        - properties:
-                            insecureEdgeTerminationPolicy:
-                              enum:
-                                - ""
-                                - None
-                                - Allow
-                                - Redirect
-                        - not:
-                            properties:
-                              termination:
-                                enum:
-                                  - edge
-                                  - reencrypt
-                    - anyOf:
-                        - properties:
-                            insecureEdgeTerminationPolicy:
-                              enum:
-                                - ""
-                                - None
-                                - Redirect
-                        - not:
-                            properties:
-                              termination:
-                                enum:
-                                  - passthrough
                   description: The tls field provides the ability to configure certificates and termination for the route.
                   properties:
                     caCertificate:
@@ -189,7 +163,12 @@ spec:
                       description: destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt termination this file should be provided in order to have routers use it for health checks on the secure connection. If this field is not specified, the router may provide its own destination CA and perform hostname validation using the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically verify.
                       type: string
                     insecureEdgeTerminationPolicy:
-                      description: "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80. \n * Allow - traffic is sent to the server on the insecure port (default) * Disable - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port."
+                      description: "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80. \n * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default). * None - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port."
+                      enum:
+                        - Allow
+                        - None
+                        - Redirect
+                        - ""
                       type: string
                     key:
                       description: key provides key file contents
@@ -204,6 +183,9 @@ spec:
                   required:
                     - termination
                   type: object
+                  x-kubernetes-validations:
+                    - message: 'cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow'
+                      rule: 'has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination==''passthrough'') && (self.insecureEdgeTerminationPolicy==''Allow'')) : true'
                 to:
                   description: to is an object the route should use as the primary backend. Only the Service kind is allowed, and it will be defaulted to Service. If the weight field (0-256 default 100) is set to zero, no traffic will be sent to this backend.
                   properties:

--- a/vendor/github.com/openshift/api/route/v1/route.crd.yaml-patch
+++ b/vendor/github.com/openshift/api/route/v1/route.crd.yaml-patch
@@ -65,22 +65,3 @@
         properties:
           termination:
             enum: ["edge"]
-  # Any insecure edge-termination policy may be used if we terminate TLS.
-  - anyOf:
-    - properties:
-        insecureEdgeTerminationPolicy:
-          enum: ["", "None", "Allow", "Redirect"]
-    - not:
-        properties:
-          termination:
-            enum: ["edge","reencrypt"]
-  # Any insecure edge-termination policy *except* for "Allow" maybe used when
-  # using passthrough TLS.
-  - anyOf:
-    - properties:
-        insecureEdgeTerminationPolicy:
-          enum: ["", "None", "Redirect"]
-    - not:
-        properties:
-          termination:
-            enum: ["passthrough"]

--- a/vendor/github.com/openshift/api/route/v1/stable.route.testsuite.yaml
+++ b/vendor/github.com/openshift/api/route/v1/stable.route.testsuite.yaml
@@ -20,3 +20,65 @@ tests:
           name: foo
           weight: 100
         wildcardPolicy: None
+  - name: "cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow"
+    initial: |
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      spec:
+        to:
+          kind: Service
+          name: foo
+        tls:
+          termination: passthrough
+          insecureEdgeTerminationPolicy: Allow
+    expectedError: "cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow"
+  - name: "spec.tls.termination: passthrough is compatible with spec.tls.insecureEdgeTerminationPolicy: Redirect"
+    initial: |
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      spec:
+        host: test.foo
+        to:
+          kind: Service
+          name: foo
+        tls:
+          termination: passthrough
+          insecureEdgeTerminationPolicy: Redirect
+    expected: |
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      spec:
+        host: test.foo
+        to:
+          kind: Service
+          name: foo
+          weight: 100
+        tls:
+          termination: passthrough
+          insecureEdgeTerminationPolicy: Redirect
+        wildcardPolicy: None
+  - name: "spec.tls.termination: passthrough is compatible with spec.tls.insecureEdgeTerminationPolicy: None"
+    initial: |
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      spec:
+        host: test.foo
+        to:
+          kind: Service
+          name: foo
+        tls:
+          termination: passthrough
+          insecureEdgeTerminationPolicy: None
+    expected: |
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      spec:
+        host: test.foo
+        to:
+          kind: Service
+          name: foo
+          weight: 100
+        tls:
+          termination: passthrough
+          insecureEdgeTerminationPolicy: None
+        wildcardPolicy: None

--- a/vendor/github.com/openshift/api/route/v1/types.go
+++ b/vendor/github.com/openshift/api/route/v1/types.go
@@ -246,6 +246,8 @@ type RouterShard struct {
 }
 
 // TLSConfig defines config used to secure a route and provide termination
+//
+// +kubebuilder:validation:XValidation:rule="has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination=='passthrough') && (self.insecureEdgeTerminationPolicy=='Allow')) : true", message="cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow"
 type TLSConfig struct {
 	// termination indicates termination type.
 	//
@@ -276,9 +278,11 @@ type TLSConfig struct {
 	// insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While
 	// each router may make its own decisions on which ports to expose, this is normally port 80.
 	//
-	// * Allow - traffic is sent to the server on the insecure port (default)
-	// * Disable - no traffic is allowed on the insecure port.
+	// * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default).
+	// * None - no traffic is allowed on the insecure port.
 	// * Redirect - clients are redirected to the secure port.
+	//
+	// +kubebuilder:validation:Enum=Allow;None;Redirect;""
 	InsecureEdgeTerminationPolicy InsecureEdgeTerminationPolicyType `json:"insecureEdgeTerminationPolicy,omitempty" protobuf:"bytes,6,opt,name=insecureEdgeTerminationPolicy,casttype=InsecureEdgeTerminationPolicyType"`
 }
 

--- a/vendor/github.com/openshift/api/route/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/route/v1/zz_generated.swagger_doc_generated.go
@@ -120,7 +120,7 @@ var map_TLSConfig = map[string]string{
 	"key":                           "key provides key file contents",
 	"caCertificate":                 "caCertificate provides the cert authority certificate contents",
 	"destinationCACertificate":      "destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt termination this file should be provided in order to have routers use it for health checks on the secure connection. If this field is not specified, the router may provide its own destination CA and perform hostname validation using the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically verify.",
-	"insecureEdgeTerminationPolicy": "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80.\n\n* Allow - traffic is sent to the server on the insecure port (default) * Disable - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.",
+	"insecureEdgeTerminationPolicy": "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80.\n\n* Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default). * None - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.",
 }
 
 func (TLSConfig) SwaggerDoc() map[string]string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,7 +349,7 @@ github.com/opencontainers/runc/libcontainer/user
 # github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78
 ## explicit
 github.com/opencontainers/runtime-spec/specs-go
-# github.com/openshift/api v0.0.0-20230503133300-8bbcb7ca7183
+# github.com/openshift/api v0.0.0-20230509100629-894b49f57a15
 ## explicit; go 1.20
 github.com/openshift/api
 github.com/openshift/api/annotations


### PR DESCRIPTION
Bump openshift/api for `route.spec.tls.insecureEdgeTerminationPolicy` documentation fix showing incorrect usage.

To achieve the bump, I ran the following commands:
```
go get github.com/openshift/api@v0.0.0-20230509100629-894b49f57a15
go mod tidy
go mod vendor
```

API Bump: https://github.com/openshift/api/pull/1438