### PR TITLE
wire openapi v3 aggregation controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /openshift-apiserver
 /_output
+.idea

--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
@@ -106,6 +106,10 @@ func NewOpenshiftAPIConfig(config *openshiftcontrolplanev1.OpenShiftAPIServerCon
 	genericConfig.MaxMutatingRequestsInFlight = int(config.ServingInfo.MaxRequestsInFlight / 2)
 	genericConfig.LongRunningFunc = apiserverconfig.IsLongRunningRequest
 	genericConfig.AggregatedDiscoveryGroupManager = aggregated.NewResourceManager("apis")
+	// do not to install the default OpenAPI handler in the aggregated apiserver
+	// as it will be handled by openapi aggregator (both v2 and v3)
+	// non-root apiservers must set this value to false
+	genericConfig.Config.SkipOpenAPIInstallation = true
 
 	etcdOptions, err := ToEtcdOptions(config.APIServerArguments, config.StorageConfig)
 	if err != nil {

--- a/pkg/cmd/openshift-apiserver/server.go
+++ b/pkg/cmd/openshift-apiserver/server.go
@@ -43,6 +43,9 @@ func RunOpenShiftAPIServer(serverConfig *openshiftcontrolplanev1.OpenShiftAPISer
 	if err := completedOpenshiftAPIServer.WithOpenAPIAggregationController(preparedOpenshiftAPIServer.GenericAPIServer); err != nil {
 		return err
 	}
+	if err := completedOpenshiftAPIServer.WithOpenAPIV3AggregationController(preparedOpenshiftAPIServer.GenericAPIServer); err != nil {
+		return err
+	}
 
 	klog.Infof("Starting master on %s (%s)", serverConfig.ServingInfo.BindAddress, version.Get().String())
 


### PR DESCRIPTION
skip default openapi installation for the apiserver aggregator. As a result of this, we can remove `delegatedAPIServer.RemoveOpenAPIData()` call in v2 aggregation controller.

similar change is being pushed into oauth-apiserver as well (https://github.com/openshift/oauth-apiserver/pull/89)

TBD:
We should remove this [commit](https://github.com/openshift/kubernetes-apiserver/commit/47b6b17b9fbc958510f1d854574573e068c4b210) from carry list on k8s-apiserver in future rebase
