### PR TITLE
AUTH-509: remove unauthenticated group from any cluster role binding

### DIFF
--- a/pkg/bootstrappolicy/policy.go
+++ b/pkg/bootstrappolicy/policy.go
@@ -767,13 +767,13 @@ func GetOpenshiftBootstrapClusterRoleBindings() []rbacv1.ClusterRoleBinding {
 			Groups(AuthenticatedGroup).
 			BindingOrDie(),
 		newOriginClusterBinding(SelfAccessReviewerRoleBindingName, SelfAccessReviewerRoleName).
-			Groups(AuthenticatedGroup, UnauthenticatedGroup).
+			Groups(AuthenticatedGroup).
 			BindingOrDie(),
 		newOriginClusterBinding(SelfProvisionerRoleBindingName, SelfProvisionerRoleName).
 			Groups(AuthenticatedOAuthGroup).
 			BindingOrDie(),
 		newOriginClusterBinding(OAuthTokenDeleterRoleBindingName, OAuthTokenDeleterRoleName).
-			Groups(AuthenticatedGroup, UnauthenticatedGroup).
+			Groups(AuthenticatedGroup).
 			BindingOrDie(),
 		newOriginClusterBinding(StatusCheckerRoleBindingName, StatusCheckerRoleName).
 			Groups(AuthenticatedGroup).
@@ -787,7 +787,7 @@ func GetOpenshiftBootstrapClusterRoleBindings() []rbacv1.ClusterRoleBinding {
 			Groups(NodesGroup).
 			BindingOrDie(),
 		newOriginClusterBinding(WebHooksRoleBindingName, WebHooksRoleName).
-			Groups(AuthenticatedGroup, UnauthenticatedGroup).
+			Groups(AuthenticatedGroup).
 			BindingOrDie(),
 		rbacv1helpers.NewClusterBinding(DiscoveryRoleName).
 			Groups(AuthenticatedGroup).
@@ -811,7 +811,7 @@ func GetOpenshiftBootstrapClusterRoleBindings() []rbacv1.ClusterRoleBinding {
 		// Everyone should be able to add a scope to their impersonation request.  It is purely tightening.
 		// This does not grant access to impersonate in general, only tighten if you already have permission.
 		rbacv1helpers.NewClusterBinding(ScopeImpersonationRoleName).
-			Groups(AuthenticatedGroup, UnauthenticatedGroup).
+			Groups(AuthenticatedGroup).
 			BindingOrDie(),
 	}
 	for i := range clusterRoleBindings {

--- a/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
+++ b/test/testdata/bootstrappolicy/bootstrap_cluster_role_bindings.yaml
@@ -96,9 +96,6 @@ items:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: system:authenticated
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:unauthenticated
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -129,9 +126,6 @@ items:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: system:authenticated
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:unauthenticated
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -192,9 +186,6 @@ items:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: system:authenticated
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:unauthenticated
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
@@ -285,9 +276,6 @@ items:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: system:authenticated
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:unauthenticated
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:


### PR DESCRIPTION
## What

Remove UnauthenticatedGroup from:

- SelfAccessReview
- OAuthTokenDelete
- WebHooksRole
- ScopeImpersonation

## Why

An unauthenticated User should have no permissions.