### PR TITLE
OCPBUGS-33574: Bump library-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/openshift/apiserver-library-go v0.0.0-20240313131158-facc40cc7688
 	github.com/openshift/build-machinery-go v0.0.0-20231128094528-1e9b1b0595c8
 	github.com/openshift/client-go v0.0.0-20240415214935-be70f772f157
-	github.com/openshift/library-go v0.0.0-20240424194921-cb8aac942b79
+	github.com/openshift/library-go v0.0.0-20240513090140-e22d25af5587
 	github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/openshift/docker-distribution/v3 v3.0.0-20240215131201-6b2f5d2f1f43 h
 github.com/openshift/docker-distribution/v3 v3.0.0-20240215131201-6b2f5d2f1f43/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
 github.com/openshift/kubernetes-apiserver v0.0.0-20240410114447-9e7c11c45dab h1:hVEUWx+0XiMkstOLlQ5BiBZTnA7WWJJf80Dc2L2FLyM=
 github.com/openshift/kubernetes-apiserver v0.0.0-20240410114447-9e7c11c45dab/go.mod h1:B0LieKVoyU7ykQvPFm7XSdIHaCHSzCzQWPFa5bqbeMQ=
-github.com/openshift/library-go v0.0.0-20240424194921-cb8aac942b79 h1:4iJrZMloPJlHfwo7NE8lWEXV/Ybg3RpV4LRv/ufd10g=
-github.com/openshift/library-go v0.0.0-20240424194921-cb8aac942b79/go.mod h1:lFwyRj0XjUf25Da3Q00y+KuaxCWTJ6YzYPDX1+96nco=
+github.com/openshift/library-go v0.0.0-20240513090140-e22d25af5587 h1:eZ79/F6bhtqoY78KRRxp5G5yITTgVatMnj5J/cYDumI=
+github.com/openshift/library-go v0.0.0-20240513090140-e22d25af5587/go.mod h1:lFwyRj0XjUf25Da3Q00y+KuaxCWTJ6YzYPDX1+96nco=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d h1:fLITXDjxMSvUDjnXs/zljIWktbST9+Om8XbrmmM7T4I=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d/go.mod h1:LJM49W8fBVSj+rvcopJZu9mgH5Tx6HwLHySIYeGeu4k=
 github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b h1:oXzC1N6E9gw76/WH2gEA8GEHvuq09wuVQ9GoCuR8GF4=

--- a/vendor/github.com/openshift/library-go/pkg/route/validation/validation.go
+++ b/vendor/github.com/openshift/library-go/pkg/route/validation/validation.go
@@ -352,7 +352,7 @@ func validateTLSExternalCertificate(ctx context.Context, route *routev1.Route, f
 	secret, err := secretsGetter.Secrets(route.Namespace).Get(ctx, tls.ExternalCertificate.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return append(errs, field.NotFound(fldPath, err))
+			return append(errs, field.NotFound(fldPath, err.Error()))
 		}
 		return append(errs, field.InternalError(fldPath, err))
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -595,7 +595,7 @@ github.com/openshift/client-go/user/clientset/versioned/fake
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1/fake
-# github.com/openshift/library-go v0.0.0-20240424194921-cb8aac942b79
+# github.com/openshift/library-go v0.0.0-20240513090140-e22d25af5587
 ## explicit; go 1.21
 github.com/openshift/library-go/pkg/apiserver/admission/admissionregistrationtesting
 github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig


### PR DESCRIPTION
Bump  https://github.com/openshift/library-go/commit/e22d25af55872cb4e4cbaef1e7d45ebf1d2dad5f
To reduce error message details for Not Found secret inside `validateTLSExternalCertificate()`

Vendors https://github.com/openshift/library-go/pull/1735
Fixes [OCPBUGS-33574](https://issues.redhat.com//browse/OCPBUGS-33574)