### PR TITLE
MULTIARCH-4558: Set default for imagestreamImportMode based on observed config changes in the image config

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
+++ b/pkg/cmd/openshift-apiserver/openshiftapiserver/config.go
@@ -17,6 +17,7 @@ import (
 	routehostassignment "github.com/openshift/library-go/pkg/route/hostassignment"
 	"github.com/openshift/openshift-apiserver/pkg/cmd/openshift-apiserver/openshiftadmission"
 	"github.com/openshift/openshift-apiserver/pkg/cmd/openshift-apiserver/openshiftapiserver/configprocessing"
+	apisimage "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registryhostname"
 	"github.com/openshift/openshift-apiserver/pkg/version"
 	"github.com/spf13/pflag"
@@ -264,6 +265,7 @@ func NewOpenshiftAPIConfig(config *openshiftcontrolplanev1.OpenShiftAPIServerCon
 			AllowedRegistriesForImport:         config.ImagePolicyConfig.AllowedRegistriesForImport,
 			MaxImagesBulkImportedPerRepository: config.ImagePolicyConfig.MaxImagesBulkImportedPerRepository,
 			AdditionalTrustedCA:                caData,
+			ImageStreamImportMode:              apisimage.ImportModeType(config.ImagePolicyConfig.ImageStreamImportMode),
 			RouteAllocator:                     routeAllocator,
 			AllowRouteExternalCertificates:     feature.DefaultFeatureGate.Enabled(featuregate.Feature(openshiftfeatures.FeatureGateRouteExternalCertificate)),
 			ProjectAuthorizationCache:          projectAuthorizationCache,

--- a/pkg/image/apis/image/types.go
+++ b/pkg/image/apis/image/types.go
@@ -298,6 +298,8 @@ const (
 	ImportModePreserveOriginal ImportModeType = "PreserveOriginal"
 )
 
+var DefaultImportMode ImportModeType = ImportModeLegacy
+
 // TagReferencePolicyType describes how pull-specs for images in an image stream tag are generated when
 // image change triggers are fired.
 type TagReferencePolicyType string

--- a/pkg/image/apis/image/v1/defaults.go
+++ b/pkg/image/apis/image/v1/defaults.go
@@ -5,6 +5,7 @@ import (
 
 	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/openshift/library-go/pkg/image/reference"
+	apisimage "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
 )
 
 func SetDefaults_ImageImportSpec(obj *imagev1.ImageImportSpec) {
@@ -25,6 +26,6 @@ func SetDefaults_TagReferencePolicy(obj *imagev1.TagReferencePolicy) {
 
 func SetDefaults_TagImportPolicy(obj *imagev1.TagImportPolicy) {
 	if len(obj.ImportMode) == 0 {
-		obj.ImportMode = imagev1.ImportModeLegacy
+		obj.ImportMode = imagev1.ImportModeType(apisimage.DefaultImportMode)
 	}
 }


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/1605, there was a
new field introduced in the image config spec and status which reflects
the global value to be set for imagestream import mode which is behind a
featuregate. This PR reads the observed config, checks if the importmode
string is present and uses it as the default when creating imagestreams.

API changes: https://github.com/openshift/api/pull/1928
cluster-openshift-apiserver-operator changes: https://github.com/openshift/cluster-openshift-apiserver-operator/pull/582
image-registry-operator changes: https://github.com/openshift/cluster-image-registry-operator/pull/109