### PR TITLE
OCPBUGS-44693: Bump k8s.io/apiserver fork.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -194,7 +194,7 @@ replace (
 	k8s.io/api => k8s.io/api v0.31.1
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.31.1
 	k8s.io/apimachinery => k8s.io/apimachinery v0.31.1
-	k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20241112103933-0f10e4260855 // points to openshift-apiserver-4.18-kubernetes-1.31.1
+	k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20241127162127-cd4433eedbbe // points to openshift-apiserver-4.18-kubernetes-1.31.1
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.31.1
 	k8s.io/client-go => k8s.io/client-go v0.31.1
 	k8s.io/cloud-provider => k8s.io/cloud-provider v0.31.1

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f h1:FRc0bVNWpri
 github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f/go.mod h1:KiZi2mJRH1TOJ3FtBDYS6YvUL30s/iIXaGSUrSa36mo=
 github.com/openshift/docker-distribution/v3 v3.0.0-20240215131201-6b2f5d2f1f43 h1:iFiveehT5yqHvAxdTwHGZLTxyxzMqP8bLcQKz6Y7NQQ=
 github.com/openshift/docker-distribution/v3 v3.0.0-20240215131201-6b2f5d2f1f43/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
-github.com/openshift/kubernetes-apiserver v0.0.0-20241112103933-0f10e4260855 h1:sxkHh3Bhcqg/tkoPN3s9bdCHri4V+nR4hVwXoRTK34I=
-github.com/openshift/kubernetes-apiserver v0.0.0-20241112103933-0f10e4260855/go.mod h1:lzDhpeToamVZJmmFlaLwdYZwd7zB+WYRYIboqA1kGxM=
+github.com/openshift/kubernetes-apiserver v0.0.0-20241127162127-cd4433eedbbe h1:+3kPEuOP4DMDHgWB3oR11eZ6jVU6uWED08LO3DpIcUo=
+github.com/openshift/kubernetes-apiserver v0.0.0-20241127162127-cd4433eedbbe/go.mod h1:lzDhpeToamVZJmmFlaLwdYZwd7zB+WYRYIboqA1kGxM=
 github.com/openshift/library-go v0.0.0-20241107160307-0064ad7bd060 h1:jiDC7d8d+jmjv2WfiMY0+Uf55q11MGyYkGGqXnfqWTU=
 github.com/openshift/library-go v0.0.0-20241107160307-0064ad7bd060/go.mod h1:9B1MYPoLtP9tqjWxcbUNVpwxy68zOH/3EIP6c31dAM0=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d h1:fLITXDjxMSvUDjnXs/zljIWktbST9+Om8XbrmmM7T4I=

--- a/vendor/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/vendor/k8s.io/apiserver/pkg/features/kube_features.go
@@ -388,7 +388,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	RemainingItemCount: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.32
 
-	ResilientWatchCacheInitialization: {Default: true, PreRelease: featuregate.Beta},
+	// Disabled temporarily until cause of storage error triggering cache reinitialization during bootstrap is fixed: https://issues.redhat.com/browse/OCPBUGS-45126.
+	ResilientWatchCacheInitialization: {Default: false, PreRelease: featuregate.Beta},
 
 	RetryGenerateName: {Default: true, PreRelease: featuregate.Beta},
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1309,7 +1309,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/apiserver v0.31.1 => github.com/openshift/kubernetes-apiserver v0.0.0-20241112103933-0f10e4260855
+# k8s.io/apiserver v0.31.1 => github.com/openshift/kubernetes-apiserver v0.0.0-20241127162127-cd4433eedbbe
 ## explicit; go 1.22.0
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/configuration
@@ -2343,7 +2343,7 @@ sigs.k8s.io/yaml/goyaml.v3
 # k8s.io/api => k8s.io/api v0.31.1
 # k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.31.1
 # k8s.io/apimachinery => k8s.io/apimachinery v0.31.1
-# k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20241112103933-0f10e4260855
+# k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20241127162127-cd4433eedbbe
 # k8s.io/cli-runtime => k8s.io/cli-runtime v0.31.1
 # k8s.io/client-go => k8s.io/client-go v0.31.1
 # k8s.io/cloud-provider => k8s.io/cloud-provider v0.31.1


### PR DESCRIPTION
This temporarily disables ResilientWatchCacheInitialization (see https://issues.redhat.com/browse/OCPBUGS-44693).