### PR TITLE
OCPBUGS-44432: Skip blocked registry check for registries with mirrors

### DIFF
--- a/pkg/image/apiserver/importer/importer.go
+++ b/pkg/image/apiserver/importer/importer.go
@@ -138,6 +138,9 @@ func (imp *ImageStreamImporter) blockedRegistry(ref imageapi.DockerImageReferenc
 	}
 	regURL := ref.DockerClientDefaults().Registry
 	for _, reg := range imp.regConf.Registries {
+		if len(reg.Mirrors) > 0 {
+			continue
+		}
 		if reg.Location == regURL {
 			return reg.Blocked
 		}


### PR DESCRIPTION
Do not return the blocked error as with the NeverContactSource configuration from IDMS ITMS, the image is not considered blocked. While the actual source from the image specification is blocked when the source gets redirected to the mirrors.

Create the ITMS setting NeverContactSource
```yaml
apiVersion: config.openshift.io/v1
kind: ImageTagMirrorSet
metadata:
  name: tag-mirror
spec:
  imageTagMirrors:
  - mirrors:
    - quay.io
    source: foo.io
    mirrorSourcePolicy: NeverContactSource
```
import an image from the source, no blocked error returned

```
$ oc import-image imgstream --from=foo.io/qiwanredhat/busybox:latest --confirm
imagestream.image.openshift.io/imgstream imported

Name:			imgstream
Namespace:		default
Created:		Less than a second ago
Labels:			<none>
Annotations:		openshift.io/image.dockerRepositoryCheck=2025-01-10T17:48:07Z
Image Repository:	image-registry.openshift-image-registry.svc:5000/default/imgstream
Image Lookup:		local=false
Unique Images:		1
Tags:			1

latest
  tagged from foo.io/qiwanredhat/busybox:latest

  * foo.io/qiwanredhat/busybox@sha256:4f0e11c02c63611ec6aa5ba426f299a8063e130d3e9aedc1bd6c0a13a1bebb3c
      Less than a second ago

Image Name:	imgstream:latest
Docker Image:	foo.io/qiwanredhat/busybox@sha256:4f0e11c02c63611ec6aa5ba426f299a8063e130d3e9aedc1bd6c0a13a1bebb3c
Name:		sha256:4f0e11c02c63611ec6aa5ba426f299a8063e130d3e9aedc1bd6c0a13a1bebb3c
Created:	Less than a second ago
Annotations:	image.openshift.io/dockerLayersOrder=ascending
Image Size:	728kB in 2 layers
Layers:		728kB	sha256:90e01955edcd85dac7985b72a8374545eac617ccdddcc992b732e43cd42534af
		32B	sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4
Image Created:	6 years ago
Author:		<none>
Arch:		amd64
Command:	sh
Working Dir:	<none>
User:		<none>
Exposes Ports:	<none>
Docker Labels:	<none>
Environment:	PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

```