### PR TITLE
OCPBUGS-45861: prevent panic when no image and error are set

### DIFF
--- a/pkg/image/apiserver/importer/importer.go
+++ b/pkg/image/apiserver/importer/importer.go
@@ -390,6 +390,26 @@ func (imp *ImageStreamImporter) importFromRepository(ctx context.Context, isi *i
 	status.Images = make([]imageapi.ImageImportStatus, len(repo.Tags))
 	for i, tag := range repo.Tags {
 		status.Images[i].Tag = tag.Name
+
+		// we have seen the below state in our internal CI clusters. we think
+		// it's caused by outages in the upstream registry, but we're not sure
+		// exactly how we end up in this situation where neither error or image
+		// are set. to protect against that we throw a generic error when it
+		// happens.
+		// See the following issues for details:
+		// - https://issues.redhat.com/browse/OCPBUGS-45861
+		// - https://issues.redhat.com/browse/OCPBUGS-35036
+		if tag.Image == nil && tag.Err == nil {
+			errMsg := fmt.Sprintf(
+				"unknown error while importing tag %q from repository %q with import mode %q, please try again.",
+				tag.Name,
+				repo.Name,
+				tag.ImportMode,
+			)
+			tag.Err = errors.New(errMsg)
+			klog.Infof("importFromRepository: both tag image and error are nil! repo=%+v tag=%+v", repo, tag)
+		}
+
 		if tag.Err != nil {
 			failures++
 			status.Images[i].Status = imageImportStatus(tag.Err, "", "repository")


### PR DESCRIPTION
in our ci we are seeing a series of panics being generated when we attempt to import some images. it is not clear yet how we end up with a missing image together with a nil error.

this pr introduces a check, similar to what has been done for https://issues.redhat.com/browse/OCPBUGS-35036, this new check logs the occurence and reports the error back using the cluster resource.

this is what panic trace:

```
2025-01-09T13:15:39.559789879Z E0109 13:15:39.559758       1 audit.go:84] "Observed a panic" panic=<
2025-01-09T13:15:39.559789879Z >runtime error: invalid memory address or nil pointer dereference
2025-01-09T13:15:39.559789879Z >goroutine 451090 [running]:
2025-01-09T13:15:39.559789879Z >k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest.func1.1()
2025-01-09T13:15:39.559789879Z >>       k8s.io/apiserver@v0.31.1/pkg/endpoints/handlers/finisher/finisher.go:105 +0x98
2025-01-09T13:15:39.559789879Z >panic({0x51d4180?, 0x83c2430?})
2025-01-09T13:15:39.559789879Z >>       runtime/panic.go:785 +0x124
2025-01-09T13:15:39.559789879Z >github.com/openshift/openshift-apiserver/pkg/image/apiserver/importer.(*ImageStreamImporter).importFromRepository(0x400b998100, {0x5fc2b90, 0x4007a9cf60}, 0x400590cdc0)
2025-01-09T13:15:39.559789879Z >>       github.com/openshift/openshift-apiserver/pkg/image/apiserver/importer/importer.go:400 +0xc70
2025-01-09T13:15:39.559789879Z >github.com/openshift/openshift-apiserver/pkg/image/apiserver/importer.(*ImageStreamImporter).Import(0x400b998100, {0x5fc2b90, 0x4007a9cf60}, 0x400590cdc0, 0x400590da20)
2025-01-09T13:15:39.559789879Z >>       github.com/openshift/openshift-apiserver/pkg/image/apiserver/importer/importer.go:112 +0x144
2025-01-09T13:15:39.559789879Z >github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/imagestreamimport.(*REST).Create(0x4001bbc240, {0x5fc2b90, 0x4007a9cf60}, {0x5f92ae0, 0x400590cdc0?}, 0x4005906500, 0x0?)
2025-01-09T13:15:39.559789879Z >>       github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/imagestreamimport/rest.go:337 +0x11d4
2025-01-09T13:15:39.559789879Z >k8s.io/apiserver/pkg/endpoints/handlers.(*namedCreaterAdapter).Create(0x5f860c0?, {0x5fc2b90?, 0x4007a9cf60?}, {0x400922efc0?, 0x5fc82e0?}, {0x5f92ae0?, 0x400590cdc0?}, 0xffff44427290?, 0x1?)
2025-01-09T13:15:39.559789879Z >>       k8s.io/apiserver@v0.31.1/pkg/endpoints/handlers/create.go:254 +0x48
2025-01-09T13:15:39.559789879Z >k8s.io/apiserver/pkg/endpoints/handlers.CreateResource.createHandler.func1.1()
2025-01-09T13:15:39.559789879Z >>       k8s.io/apiserver@v0.31.1/pkg/endpoints/handlers/create.go:184 +0xbc
2025-01-09T13:15:39.559789879Z >k8s.io/apiserver/pkg/endpoints/handlers.CreateResource.createHandler.func1.2()
2025-01-09T13:15:39.559789879Z >>       k8s.io/apiserver@v0.31.1/pkg/endpoints/handlers/create.go:209 +0x2e0
2025-01-09T13:15:39.559789879Z >k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest.func1()
2025-01-09T13:15:39.559789879Z >>       k8s.io/apiserver@v0.31.1/pkg/endpoints/handlers/finisher/finisher.go:117 +0x74
2025-01-09T13:15:39.559789879Z >created by k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest in goroutine 450991
2025-01-09T13:15:39.559789879Z >>       k8s.io/apiserver@v0.31.1/pkg/endpoints/handlers/finisher/finisher.go:92 +0xa4
```