### PR TITLE
OCPBUGS-45861: move on to the next digest/tag during failures

### DIFF
--- a/pkg/image/apiserver/importer/importer.go
+++ b/pkg/image/apiserver/importer/importer.go
@@ -791,7 +791,7 @@ func (imp *ImageStreamImporter) importRepositoryFromDocker(ctx context.Context, 
 					"unable to import manifest list %q: %v",
 					ref.Exact(), err)
 				importDigest.Err = err
-				return
+				continue
 			}
 			importDigest.Manifests = images
 		}
@@ -886,7 +886,7 @@ func (imp *ImageStreamImporter) importRepositoryFromDocker(ctx context.Context, 
 					"unable to import manifest list %q: %v",
 					ref.Exact(), err)
 				importTag.Err = err
-				return
+				continue
 			}
 			importTag.Manifests = images
 		}


### PR DESCRIPTION
if we fail to process a given tag or digest we should move to the next and not return. if we "prematurely" return we may cause some of the tags or digest have their Image pointer nulled, possibly causing a panic.