### PR TITLE
fix unit test failure caused by coreos/etcd removing latest tag

### DIFF
--- a/pkg/image/apiserver/importer/import_integration_test.go
+++ b/pkg/image/apiserver/importer/import_integration_test.go
@@ -93,7 +93,7 @@ func TestImageStreamImportQuayIO(t *testing.T) {
 	rt, _ := restclient.TransportFor(&restclient.Config{})
 	importCtx := importer.NewStaticCredentialsContext(rt, nil, nil)
 
-	repositoryName := quayRegistryName + "/coreos/etcd"
+	repositoryName := quayRegistryName + "/coreos/etcd-operator"
 	imports := &imageapi.ImageStreamImport{
 		Spec: imageapi.ImageStreamImportSpec{
 			Images: []imageapi.ImageImportSpec{


### PR DESCRIPTION
Use `quay.io/coreos/etcd-operator` repository in the test.  The unit test [TestImageStreamImportQuayIO](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_openshift-apiserver/502/pull-ci-openshift-openshift-apiserver-master-unit/1904054487014707200) failed because `quay.io/coreos/etcd` removes the latest tag. 