### PR TITLE
Update gitlab.go to fix webhook build issues.

### DIFF
--- a/pkg/build/apiserver/webhook/gitlab/gitlab.go
+++ b/pkg/build/apiserver/webhook/gitlab/gitlab.go
@@ -62,7 +62,7 @@ func (p *WebHookPlugin) Extract(buildCfg *buildv1.BuildConfig, trigger *buildv1.
 		return revision, envvars, dockerStrategyOptions, proceed, err
 	}
 
-	lastCommit := event.Commits[len(event.Commits)-1]
+	lastCommit := event.Commits[0]
 
 	revision = &buildv1.SourceRevision{
 		Git: &buildv1.GitSourceRevision{


### PR DESCRIPTION
Fixes: OCPBUGS-16605

Gitlab some time back, with https://gitlab.com/gitlab-org/gitlab/-/merge_requests/68168,  changed its behavior to list commits order, presented from the webhook implementation, from oldest-to-newest to newest-to-oldest  (back as far as the 14.x versions of gitlab). 

This change fixes the webhook controllers behavior so that it properly selects the latest build when a new build is triggered.