### PR TITLE
OCPBUGS-35855: Wire dry run option to Image API server operations

### DIFF
--- a/pkg/image/apiserver/admission/limitrange/admission.go
+++ b/pkg/image/apiserver/admission/limitrange/admission.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/internalimageutil"
+	internalimageutil "github.com/openshift/openshift-apiserver/pkg/image/apiserver/internal/imageutil"
 
 	"k8s.io/klog/v2"
 

--- a/pkg/image/apiserver/importer/importer.go
+++ b/pkg/image/apiserver/importer/importer.go
@@ -33,7 +33,7 @@ import (
 	"github.com/openshift/library-go/pkg/image/imageutil"
 	imageref "github.com/openshift/library-go/pkg/image/reference"
 	imageapi "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
-	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/internalimageutil"
+	internalimageutil "github.com/openshift/openshift-apiserver/pkg/image/apiserver/internal/imageutil"
 )
 
 // Interface loads images into an image stream import request.

--- a/pkg/image/apiserver/internal/imageutil/helpers.go
+++ b/pkg/image/apiserver/internal/imageutil/helpers.go
@@ -1,4 +1,4 @@
-package internalimageutil
+package imageutil
 
 import (
 	"encoding/json"

--- a/pkg/image/apiserver/internal/imageutil/helpers_test.go
+++ b/pkg/image/apiserver/internal/imageutil/helpers_test.go
@@ -1,4 +1,4 @@
-package internalimageutil
+package imageutil
 
 import (
 	"reflect"

--- a/pkg/image/apiserver/internalimageutil/helpers.go
+++ b/pkg/image/apiserver/internalimageutil/helpers.go
@@ -519,3 +519,67 @@ func HasTagCondition(stream *imageapi.ImageStream, tag string, condition imageap
 	}
 	return false
 }
+
+// UpdateOptionsToSupportedUpdateOptions prepares an UpdateOptions resource by using
+// the specific selected options from the UpdateOptions.
+// In the future, other fields like fieldManager can also be supported.
+func UpdateOptionsToSupportedUpdateOptions(opts *metav1.UpdateOptions) *metav1.UpdateOptions {
+	if opts == nil {
+		return &metav1.UpdateOptions{}
+	}
+	return &metav1.UpdateOptions{
+		DryRun: opts.DryRun,
+	}
+}
+
+// CreateOptionsToSupportedUpdateOptions prepares an UpdateOptions resource by using
+// the specific selected options from the CreateOptions.
+// In the future, other fields like fieldManager can also be supported.
+func CreateOptionsToSupportedUpdateOptions(opts *metav1.CreateOptions) *metav1.UpdateOptions {
+	if opts == nil {
+		return &metav1.UpdateOptions{}
+	}
+
+	return &metav1.UpdateOptions{
+		DryRun: opts.DryRun,
+	}
+}
+
+// CreateOptionsToSupportedCreateOptions prepares an CreateOptions resource by using
+// the specific selected options from the CreateOptions.
+// In the future, other fields like fieldManager can also be supported.
+func CreateOptionsToSupportedCreateOptions(opts *metav1.CreateOptions) *metav1.CreateOptions {
+	if opts == nil {
+		return &metav1.CreateOptions{}
+	}
+
+	return &metav1.CreateOptions{
+		DryRun: opts.DryRun,
+	}
+}
+
+// UpdateOptionsToSupportedCreateOptions prepares an CreateOptions resource by using
+// the specific selected options from the UpdateOptions.
+// In the future, other fields like fieldManager can also be supported.
+func UpdateOptionsToSupportedCreateOptions(opts *metav1.UpdateOptions) *metav1.CreateOptions {
+	if opts == nil {
+		return &metav1.CreateOptions{}
+	}
+
+	return &metav1.CreateOptions{
+		DryRun: opts.DryRun,
+	}
+}
+
+// DeleteOptionsToSupportedUpdateOptions prepares an UpdateOptions resource by using
+// the specific selected options from the DeleteOptions.
+// In the future, other fields like fieldManager can also be supported.
+func DeleteOptionsToSupportedUpdateOptions(opts *metav1.DeleteOptions) *metav1.UpdateOptions {
+	if opts == nil {
+		return &metav1.UpdateOptions{}
+	}
+
+	return &metav1.UpdateOptions{
+		DryRun: opts.DryRun,
+	}
+}

--- a/pkg/image/apiserver/registry/image/strategy.go
+++ b/pkg/image/apiserver/registry/image/strategy.go
@@ -16,7 +16,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 	imageapi "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
 	"github.com/openshift/openshift-apiserver/pkg/image/apis/image/validation"
-	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/internalimageutil"
+	internalimageutil "github.com/openshift/openshift-apiserver/pkg/image/apiserver/internal/imageutil"
 )
 
 // managedSignatureAnnotation used to be set by image signature import controller as a signature annotation.

--- a/pkg/image/apiserver/registry/imagestream/registry.go
+++ b/pkg/image/apiserver/registry/imagestream/registry.go
@@ -76,7 +76,7 @@ func (s *storage) GetImageStream(ctx context.Context, imageStreamID string, opti
 }
 
 func (s *storage) CreateImageStream(ctx context.Context, imageStream *imageapi.ImageStream, options *metav1.CreateOptions) (*imageapi.ImageStream, error) {
-	obj, err := s.Create(ctx, imageStream, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
+	obj, err := s.Create(ctx, imageStream, rest.ValidateAllObjectFunc, options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/image/apiserver/registry/imagestream/strategy.go
+++ b/pkg/image/apiserver/registry/imagestream/strategy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/internalimageutil"
+	internalimageutil "github.com/openshift/openshift-apiserver/pkg/image/apiserver/internal/imageutil"
 
 	authorizationapi "k8s.io/api/authorization/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/image/apiserver/registry/imagestreamimage/rest.go
+++ b/pkg/image/apiserver/registry/imagestreamimage/rest.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift/library-go/pkg/image/imageutil"
 
 	imageapi "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
-	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/internalimageutil"
+	internalimageutil "github.com/openshift/openshift-apiserver/pkg/image/apiserver/internal/imageutil"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/image"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/imagestream"
 	imageprinters "github.com/openshift/openshift-apiserver/pkg/image/printers/internalversion"

--- a/pkg/image/apiserver/registry/imagestreamimport/imagecreater.go
+++ b/pkg/image/apiserver/registry/imagestreamimport/imagecreater.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/klog/v2"
 
 	imageapi "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
-	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/internalimageutil"
+	internalimageutil "github.com/openshift/openshift-apiserver/pkg/image/apiserver/internal/imageutil"
 )
 
 type cachedImageCreater struct {

--- a/pkg/image/apiserver/registry/imagestreamimport/rest.go
+++ b/pkg/image/apiserver/registry/imagestreamimport/rest.go
@@ -39,7 +39,7 @@ import (
 	"github.com/openshift/openshift-apiserver/pkg/image/apis/image/validation"
 	"github.com/openshift/openshift-apiserver/pkg/image/apis/image/validation/whitelist"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/importer"
-	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/internalimageutil"
+	internalimageutil "github.com/openshift/openshift-apiserver/pkg/image/apiserver/internal/imageutil"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/imagestream"
 	"github.com/openshift/runtime-utils/pkg/registries"
 )

--- a/pkg/image/apiserver/registry/imagestreammapping/rest.go
+++ b/pkg/image/apiserver/registry/imagestreammapping/rest.go
@@ -20,7 +20,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 	imagereference "github.com/openshift/library-go/pkg/image/reference"
 	imageapi "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
-	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/internalimageutil"
+	internalimageutil "github.com/openshift/openshift-apiserver/pkg/image/apiserver/internal/imageutil"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/image"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/imagestream"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registryhostname"

--- a/pkg/image/apiserver/registry/imagestreammapping/rest_test.go
+++ b/pkg/image/apiserver/registry/imagestreammapping/rest_test.go
@@ -30,7 +30,7 @@ import (
 	imageapi "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
 	"github.com/openshift/openshift-apiserver/pkg/image/apis/image/validation/fake"
 	admfake "github.com/openshift/openshift-apiserver/pkg/image/apiserver/admission/fake"
-	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/internalimageutil"
+	internalimageutil "github.com/openshift/openshift-apiserver/pkg/image/apiserver/internal/imageutil"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/image"
 	imageetcd "github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/image/etcd"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/imagestream"

--- a/pkg/image/apiserver/registry/imagestreamtag/rest.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/rest.go
@@ -202,9 +202,9 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		// Check the stream creation timestamp and make sure we will not
 		// create a new image stream while deleting.
 		if target.CreationTimestamp.IsZero() {
-			target, err = r.imageStreamRegistry.CreateImageStream(ctx, target, &metav1.CreateOptions{})
+			target, err = r.imageStreamRegistry.CreateImageStream(ctx, target, internalimageutil.CreateOptionsToSupportedCreateOptions(options))
 		} else {
-			target, err = r.imageStreamRegistry.UpdateImageStream(ctx, target, false, &metav1.UpdateOptions{})
+			target, err = r.imageStreamRegistry.UpdateImageStream(ctx, target, false, internalimageutil.CreateOptionsToSupportedUpdateOptions(options))
 		}
 		if kapierrors.IsAlreadyExists(err) || kapierrors.IsConflict(err) {
 			continue
@@ -360,9 +360,9 @@ func (r *REST) update(ctx context.Context, tagName string, objInfo rest.UpdatedO
 	// mutate the image stream
 	var newImageStream *imageapi.ImageStream
 	if create {
-		newImageStream, err = r.imageStreamRegistry.CreateImageStream(ctx, originalImageStream, &metav1.CreateOptions{})
+		newImageStream, err = r.imageStreamRegistry.CreateImageStream(ctx, originalImageStream, internalimageutil.UpdateOptionsToSupportedCreateOptions(options))
 	} else {
-		newImageStream, err = r.imageStreamRegistry.UpdateImageStream(ctx, originalImageStream, false, &metav1.UpdateOptions{})
+		newImageStream, err = r.imageStreamRegistry.UpdateImageStream(ctx, originalImageStream, false, internalimageutil.UpdateOptionsToSupportedUpdateOptions(options))
 	}
 	if err != nil {
 		// return true for canRetry if we had a failure for resource versions
@@ -422,7 +422,7 @@ func (r *REST) Delete(ctx context.Context, id string, objectFunc rest.ValidateOb
 			return nil, false, kapierrors.NewNotFound(imagegroup.Resource("imagestreamtags"), id)
 		}
 
-		_, err = r.imageStreamRegistry.UpdateImageStream(ctx, stream, false, &metav1.UpdateOptions{})
+		_, err = r.imageStreamRegistry.UpdateImageStream(ctx, stream, false, internalimageutil.DeleteOptionsToSupportedUpdateOptions(options))
 		if kapierrors.IsConflict(err) {
 			continue
 		}

--- a/pkg/image/apiserver/registry/imagestreamtag/rest.go
+++ b/pkg/image/apiserver/registry/imagestreamtag/rest.go
@@ -23,7 +23,7 @@ import (
 	"github.com/openshift/openshift-apiserver/pkg/api/apihelpers"
 	imageapi "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
 	"github.com/openshift/openshift-apiserver/pkg/image/apis/image/validation/whitelist"
-	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/internalimageutil"
+	internalimageutil "github.com/openshift/openshift-apiserver/pkg/image/apiserver/internal/imageutil"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/image"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/imagestream"
 	imageprinters "github.com/openshift/openshift-apiserver/pkg/image/printers/internalversion"

--- a/pkg/image/apiserver/registry/imagetag/rest.go
+++ b/pkg/image/apiserver/registry/imagetag/rest.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openshift/openshift-apiserver/pkg/api/apihelpers"
 	imageapi "github.com/openshift/openshift-apiserver/pkg/image/apis/image"
 	"github.com/openshift/openshift-apiserver/pkg/image/apis/image/validation/whitelist"
-	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/internalimageutil"
+	internalimageutil "github.com/openshift/openshift-apiserver/pkg/image/apiserver/internal/imageutil"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/image"
 	"github.com/openshift/openshift-apiserver/pkg/image/apiserver/registry/imagestream"
 	imageprinters "github.com/openshift/openshift-apiserver/pkg/image/printers/internalversion"

--- a/pkg/image/apiserver/registry/imagetag/rest.go
+++ b/pkg/image/apiserver/registry/imagetag/rest.go
@@ -3,7 +3,6 @@ package imagetag
 import (
 	"context"
 	"fmt"
-
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -211,9 +210,9 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		// Check the stream creation timestamp and make sure we will not
 		// create a new image stream while deleting.
 		if target.CreationTimestamp.IsZero() {
-			target, err = r.imageStreamRegistry.CreateImageStream(ctx, target, &metav1.CreateOptions{})
+			target, err = r.imageStreamRegistry.CreateImageStream(ctx, target, internalimageutil.CreateOptionsToSupportedCreateOptions(options))
 		} else {
-			target, err = r.imageStreamRegistry.UpdateImageStream(ctx, target, false, &metav1.UpdateOptions{})
+			target, err = r.imageStreamRegistry.UpdateImageStream(ctx, target, false, internalimageutil.CreateOptionsToSupportedUpdateOptions(options))
 		}
 		if kapierrors.IsAlreadyExists(err) || kapierrors.IsConflict(err) {
 			continue
@@ -323,9 +322,9 @@ func (r *REST) Update(ctx context.Context, tagName string, objInfo rest.UpdatedO
 	// mutate the image stream
 	var newImageStream *imageapi.ImageStream
 	if create {
-		newImageStream, err = r.imageStreamRegistry.CreateImageStream(ctx, imageStream, &metav1.CreateOptions{})
+		newImageStream, err = r.imageStreamRegistry.CreateImageStream(ctx, imageStream, internalimageutil.UpdateOptionsToSupportedCreateOptions(options))
 	} else {
-		newImageStream, err = r.imageStreamRegistry.UpdateImageStream(ctx, imageStream, false, &metav1.UpdateOptions{})
+		newImageStream, err = r.imageStreamRegistry.UpdateImageStream(ctx, imageStream, false, internalimageutil.UpdateOptionsToSupportedUpdateOptions(options))
 	}
 	if err != nil {
 		return nil, false, err
@@ -382,7 +381,7 @@ func (r *REST) Delete(ctx context.Context, id string, objectFunc rest.ValidateOb
 			return nil, false, kapierrors.NewNotFound(imagegroup.Resource("imagetags"), id)
 		}
 
-		_, err = r.imageStreamRegistry.UpdateImageStream(ctx, stream, false, &metav1.UpdateOptions{})
+		_, err = r.imageStreamRegistry.UpdateImageStream(ctx, stream, false, internalimageutil.DeleteOptionsToSupportedUpdateOptions(options))
 		if kapierrors.IsConflict(err) {
 			continue
 		}


### PR DESCRIPTION
Some of API servers that run in openshift-apiserver do not support dry run (like Image). So that when user passes `--dry-run=server` in oc for image related resources (as described in the linked issue), it actually performs the operation instead of simulating the operation and outputs the result. This is unwanted and disruptive behavior that may lead to undesired consequences. 

The reason of the issue is dry-run option is not wired through the storage layer of Image. This PR tries to achieve this.