### PR TITLE
OCPBUGS-57474: Requests inappropriately skipped + test

### DIFF
--- a/pkg/project/auth/cache_test.go
+++ b/pkg/project/auth/cache_test.go
@@ -296,7 +296,7 @@ func (tw *testWatcher) GroupMembershipChanged(namespaceName string, users, group
 	}{namespaceName, users, groups})
 }
 
-// TestRoleBindingRemovalNotifiesWatchers checks that when role bindings are removed during auth cache synchronization, watchers receive deleted notifications
+// TestRoleBindingRemovalNotifiesWatchers checks that when role bindings are removed, watchers receive deleted notifications
 func TestRoleBindingRemovalNotifiesWatchers(t *testing.T) {
 	namespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo", ResourceVersion: "1"}}
 
@@ -307,7 +307,7 @@ func TestRoleBindingRemovalNotifiesWatchers(t *testing.T) {
 	nsIndexer.Add(&namespace)
 	nsLister := corev1listers.NewNamespaceLister(nsIndexer)
 
-	// initial reviewer grants access to user alice\
+	// initial reviewer grants access to user alice
 	reviewer := &mockReviewer{expectedResults: map[string]*mockReview{
 		"foo": {users: []string{alice.GetName()}, groups: []string{}},
 	}}

--- a/pkg/project/auth/cache_test.go
+++ b/pkg/project/auth/cache_test.go
@@ -337,13 +337,6 @@ func TestRoleBindingRemovalNotifiesWatchers(t *testing.T) {
 
 	// simulate removal of all role bindings
 	reviewer.expectedResults["foo"] = &mockReview{users: []string{}, groups: []string{}}
-	// force update
-	rvInt, err := strconv.Atoi(namespace.ResourceVersion)
-	if err != nil {
-		t.Fatalf("failed to parse resource version: %v", err)
-	}
-	namespace.ResourceVersion = strconv.Itoa(rvInt + 1)
-	nsIndexer.Add(&namespace)
 
 	// sync again
 	authCache.synchronize()


### PR DESCRIPTION
Previously, a request that removed a role or rolebinding from a subject for which we had a cached result would be skipped unless a clusterrole/clusterrolebinding was also modified which would force a full cache invalidation. This adds more conditions to the skip checker.

cc: @benluddy 