### PR TITLE
OCPBUGS-57474: checks for removed role and role bindings

### DIFF
--- a/pkg/project/auth/cache.go
+++ b/pkg/project/auth/cache.go
@@ -553,6 +553,13 @@ func skipReview(request *reviewRequest, lastKnownValue *reviewRecord) bool {
 		}
 	}
 
+	// we also need to check if any role binding was removed.
+	for k := range lastKnownValue.roleBindingUIDToResourceVersion {
+		if _, exists := request.roleBindingUIDToResourceVersion[k]; !exists {
+			return false
+		}
+	}
+
 	// if you see a new role, or a newer version, we need to do a review
 	for k, v := range request.roleUIDToResourceVersion {
 		oldValue, exists := lastKnownValue.roleUIDToResourceVersion[k]
@@ -560,6 +567,14 @@ func skipReview(request *reviewRequest, lastKnownValue *reviewRecord) bool {
 			return false
 		}
 	}
+
+	// we also need to check if any role was removed.
+	for k := range lastKnownValue.roleUIDToResourceVersion {
+		if _, exists := request.roleUIDToResourceVersion[k]; !exists {
+			return false
+		}
+	}
+
 	return true
 }
 


### PR DESCRIPTION
if a role or role binding went missing the cache must be invalidated and reassessed (i.e. it can't be "skipped). prior to this we were checking for:

1. new roles or role bindings being added.
1. existing roles or role bindings being updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reviews are now triggered when roles or role bindings are removed, not only when they are added or updated. This closes a gap where deletions could bypass review, improving security and compliance oversight.
  * Expect more accurate detection of access changes across projects/environments, which may result in additional review prompts when permissions are reduced.
  * No changes to public APIs; impact is limited to review behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->