### PR TITLE
OCPBUGS-57474: ensure cache invalidation after a time

### DIFF
--- a/pkg/project/auth/cache.go
+++ b/pkg/project/auth/cache.go
@@ -203,13 +203,10 @@ type AuthorizationCache struct {
 	watchers    []CacheWatcher
 	watcherLock sync.Mutex
 
-	// lastCacheInvalidation and maxCacheLifespan are used together.
-	// We use them to control the maximum time allowed between cache
-	// invalidations. This is a workaround for a bug. We deemed the
-	// risk of refactoring the cache to be too high so close to the
-	// release date, so close to the release so here we are. For
-	// further details see:
-	// https://issues.redhat.com/browse/OCPBUGS-57474
+	// lastCacheInvalidation and maxCacheLifespan control the maximum time
+	// between cache invalidations. This is a temporary workaround due to
+	// release timing risk.
+	// See https://issues.redhat.com/browse/OCPBUGS-57474 for details.
 	lastCacheInvalidation time.Time
 	maxCacheLifespan      time.Duration
 }
@@ -417,7 +414,7 @@ func (ac *AuthorizationCache) invalidateCache(lastCacheInvalidation time.Time) b
 }
 
 // cacheHasExpired is used to evaluate when it is time to do a full cache
-// invalidation.
+// invalidation due to age.
 func (ac *AuthorizationCache) cacheHasExpired(lastCacheInvalidation time.Time) bool {
 	return time.Since(lastCacheInvalidation) > ac.maxCacheLifespan
 }

--- a/pkg/project/auth/cache_test.go
+++ b/pkg/project/auth/cache_test.go
@@ -264,7 +264,7 @@ func TestInvalidateCache(t *testing.T) {
 			crbs := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 			ac.clusterRoleLister = syncedClusterRoleLister{
 				ClusterRoleLister: rbacv1listers.NewClusterRoleLister(crs),
-				versioner:         informers.Rbac().V1().ClusterRoleBindings().Informer(),
+				versioner:         informers.Rbac().V1().ClusterRoles().Informer(),
 			}
 			ac.clusterRoleBindingLister = syncedClusterRoleBindingLister{
 				ClusterRoleBindingLister: rbacv1listers.NewClusterRoleBindingLister(crbs),
@@ -302,9 +302,8 @@ func TestInvalidateCacheAfterLifespan(t *testing.T) {
 	nsLister := corev1listers.NewNamespaceLister(nsIndexer)
 	reviewer := &mockReviewer{}
 	nsInformer := informers.Core().V1().Namespaces().Informer()
-	ac := NewAuthorizationCache(
-		nsLister, nsInformer, reviewer, informers.Rbac().V1(),
-	)
+	rbacClient := informers.Rbac().V1()
+	ac := NewAuthorizationCache(nsLister, nsInformer, reviewer, rbacClient)
 
 	if invalidate := ac.invalidateCache(time.Now()); invalidate {
 		t.Errorf("expected false on check first check, got true")
@@ -320,7 +319,7 @@ func TestInvalidateCacheAfterLifespan(t *testing.T) {
 	crs := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 	ac.clusterRoleLister = syncedClusterRoleLister{
 		ClusterRoleLister: rbacv1listers.NewClusterRoleLister(crs),
-		versioner:         informers.Rbac().V1().ClusterRoleBindings().Informer(),
+		versioner:         informers.Rbac().V1().ClusterRoles().Informer(),
 	}
 	crs.Add(
 		&rbacv1.ClusterRole{

--- a/pkg/project/auth/cache_test.go
+++ b/pkg/project/auth/cache_test.go
@@ -262,8 +262,14 @@ func TestInvalidateCache(t *testing.T) {
 
 			crs := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 			crbs := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-			ac.clusterRoleLister = syncedClusterRoleLister{ClusterRoleLister: rbacv1listers.NewClusterRoleLister(crs)}
-			ac.clusterRoleBindingLister = syncedClusterRoleBindingLister{ClusterRoleBindingLister: rbacv1listers.NewClusterRoleBindingLister(crbs)}
+			ac.clusterRoleLister = syncedClusterRoleLister{
+				ClusterRoleLister: rbacv1listers.NewClusterRoleLister(crs),
+				versioner:         informers.Rbac().V1().ClusterRoleBindings().Informer(),
+			}
+			ac.clusterRoleBindingLister = syncedClusterRoleBindingLister{
+				ClusterRoleBindingLister: rbacv1listers.NewClusterRoleBindingLister(crbs),
+				versioner:                informers.Rbac().V1().ClusterRoleBindings().Informer(),
+			}
 
 			for i, trial := range tc.trials {
 				func() {
@@ -314,6 +320,7 @@ func TestInvalidateCacheAfterLifespan(t *testing.T) {
 	crs := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 	ac.clusterRoleLister = syncedClusterRoleLister{
 		ClusterRoleLister: rbacv1listers.NewClusterRoleLister(crs),
+		versioner:         informers.Rbac().V1().ClusterRoleBindings().Informer(),
 	}
 	crs.Add(
 		&rbacv1.ClusterRole{


### PR DESCRIPTION
this commit ensures that we invalidate the cache at least every 15 seconds. this has been the chosen workaround for an existing bug that is on our code since long ago but just recently bubbled up in our e2e tests.

ideally we would refactor the whole cache layer but giving the time constraints we have opted-in for a more conservative approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Added a time-based TTL for the authorization cache so permissions refresh automatically (reducing stale access) while preserving existing detection of resource changes to ensure up-to-date role/permission behavior.
- Tests
  - Added unit tests validating TTL-based expiry behavior, that cache refresh occurs after lifespan expiry, and that refresh still triggers on resource changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->