### PR TITLE
WIP: NO-JIRA: Disable imagemutator admission

### DIFF
--- a/pkg/cmd/openshift-apiserver/openshiftadmission/register.go
+++ b/pkg/cmd/openshift-apiserver/openshiftadmission/register.go
@@ -6,7 +6,6 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/kubernetes/plugin/pkg/admission/gc"
 
-	"github.com/openshift/apiserver-library-go/pkg/admission/imagepolicy"
 	quotaclusterresourcequota "github.com/openshift/apiserver-library-go/pkg/admission/quota/clusterresourcequota"
 	buildsecretinjector "github.com/openshift/openshift-apiserver/pkg/build/apiserver/admission/secretinjector"
 	buildstrategyrestrictions "github.com/openshift/openshift-apiserver/pkg/build/apiserver/admission/strategyrestrictions"
@@ -37,7 +36,7 @@ func RegisterOpenshiftAdmissionPlugins(plugins *admission.Plugins) {
 	buildsecretinjector.Register(plugins)
 	buildstrategyrestrictions.Register(plugins)
 	imageadmission.Register(plugins)
-	imagepolicy.Register(plugins)
+	//imagepolicy.Register(plugins)
 	quotaclusterresourcequota.Register(plugins)
 	requiredrouteannotations.Register(plugins)
 }

--- a/pkg/cmd/openshift-apiserver/openshiftadmission/register.go
+++ b/pkg/cmd/openshift-apiserver/openshiftadmission/register.go
@@ -53,7 +53,7 @@ var (
 		"build.openshift.io/BuildConfigSecretInjector",
 		"build.openshift.io/BuildByStrategy",
 		"image.openshift.io/ImageLimitRange",
-		"image.openshift.io/ImagePolicy",
+		//"image.openshift.io/ImagePolicy",
 		"quota.openshift.io/ClusterResourceQuota",
 		"route.openshift.io/RequiredRouteAnnotations",
 


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled the image policy admission plugin; it is no longer loaded or enforced.
  * Clusters that relied on admission-based image policy checks will not have those validations applied.
  * Workloads will proceed without image policy gatekeeping from this component.
  * Administrators should verify alternative image governance or constraints remain in place.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->