### PR TITLE
OCPBUGS-61768: update pkg/image/OWNERS

### DIFF
--- a/pkg/image/OWNERS
+++ b/pkg/image/OWNERS
@@ -1,16 +1,7 @@
 reviewers:
-  - bparees
-  - soltysh
-  - mfojtik
-  - tnozicka
-  - adambkaplan
-  - dmage
+  - QiWang19
   - flavianmissi
+  - ricardomaraschini
 approvers:
-  - bparees
-  - soltysh
-  - mfojtik
-  - tnozicka
-  - adambkaplan
-  - dmage
   - flavianmissi
+  - ricardomaraschini


### PR DESCRIPTION
remove people who left ocp or red hat.
also add new contributors.

cc @ricardomaraschini & @QiWang19 

NOTE: I created a bug for this so that we can backport to previous releases more easily.