### PR TITLE
Bump openshift/kubernetes-apiserver.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ replace (
 	k8s.io/api => k8s.io/api v0.33.3
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.3
 	k8s.io/apimachinery => k8s.io/apimachinery v0.33.3
-	k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20250827071042-b0ff18f3664f // points to openshift-apiserver-4.20-kubernetes-1.33
+	k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20250917144435-182485d204aa // points to openshift-apiserver-4.20-kubernetes-1.33
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.3
 	k8s.io/client-go => k8s.io/client-go v0.33.3
 	k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.3

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/openshift/client-go v0.0.0-20250811163556-6193816ae379 h1:Xr47DBqFVjp
 github.com/openshift/client-go v0.0.0-20250811163556-6193816ae379/go.mod h1:HouQRy4JgvTBpxcyw1YSD/Lp+wjOaUrxjWFHlMtZsk8=
 github.com/openshift/docker-distribution/v3 v3.0.0-20240215131201-6b2f5d2f1f43 h1:iFiveehT5yqHvAxdTwHGZLTxyxzMqP8bLcQKz6Y7NQQ=
 github.com/openshift/docker-distribution/v3 v3.0.0-20240215131201-6b2f5d2f1f43/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
-github.com/openshift/kubernetes-apiserver v0.0.0-20250827071042-b0ff18f3664f h1:N/xAKHHCCsmNB6aqBcPitK7m4IMnYuzzLFQjENTFwqU=
-github.com/openshift/kubernetes-apiserver v0.0.0-20250827071042-b0ff18f3664f/go.mod h1:05632ifFEe6TxwjdAIrwINHWE2hLwyADFk5mBsQa15E=
+github.com/openshift/kubernetes-apiserver v0.0.0-20250917144435-182485d204aa h1:rCAG+5H7TRJvPh0H05Lv3dE3SACVsO6Afm/auqjWnDo=
+github.com/openshift/kubernetes-apiserver v0.0.0-20250917144435-182485d204aa/go.mod h1:05632ifFEe6TxwjdAIrwINHWE2hLwyADFk5mBsQa15E=
 github.com/openshift/library-go v0.0.0-20250818065802-cf8518058622 h1:IUs2XpDgkCQIIAPCVnHEjIUYiq0dvVskD/ekof7+XjQ=
 github.com/openshift/library-go v0.0.0-20250818065802-cf8518058622/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d h1:fLITXDjxMSvUDjnXs/zljIWktbST9+Om8XbrmmM7T4I=

--- a/vendor/k8s.io/apiserver/pkg/storage/etcd3/etcd3retry/retry_etcdclient.go
+++ b/vendor/k8s.io/apiserver/pkg/storage/etcd3/etcd3retry/retry_etcdclient.go
@@ -26,13 +26,43 @@ var DefaultRetry = wait.Backoff{
 }
 
 type retryClient struct {
-	// embed because we only want to override a few states
-	storage.Interface
+	// All methods of storage.Interface are implemented directly on *retryClient, even when they
+	// are purely passthroughs to the delegate. During a rebase, consider whether or not it is
+	// safe and appropriate for a new method added to the method set of storage.Interface to
+	// perform retries.
+	delegate storage.Interface
+}
+
+func (c *retryClient) Count(key string) (int64, error) {
+	return c.delegate.Count(key)
+}
+
+func (c *retryClient) ReadinessCheck() error {
+	return c.delegate.ReadinessCheck()
+}
+
+func (c *retryClient) RequestWatchProgress(ctx context.Context) error {
+	return c.delegate.RequestWatchProgress(ctx)
+}
+
+func (c *retryClient) Versioner() storage.Versioner {
+	return c.delegate.Versioner()
 }
 
 // New returns an etcd3 implementation of storage.Interface.
 func NewRetryingEtcdStorage(delegate storage.Interface) storage.Interface {
-	return &retryClient{Interface: delegate}
+	return &retryClient{delegate: delegate}
+}
+
+func (c *retryClient) GetCurrentResourceVersion(ctx context.Context) (uint64, error) {
+	var (
+		rv  uint64
+		err error
+	)
+	return rv, OnError(ctx, DefaultRetry, IsRetriableErrorOnRead, func() error {
+		rv, err = c.delegate.GetCurrentResourceVersion(ctx)
+		return err
+	})
 }
 
 // Create adds a new object at a key unless it already exists. 'ttl' is time-to-live
@@ -40,7 +70,7 @@ func NewRetryingEtcdStorage(delegate storage.Interface) storage.Interface {
 // set to the read value from database.
 func (c *retryClient) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error {
 	return OnError(ctx, DefaultRetry, IsRetriableErrorOnWrite, func() error {
-		return c.Interface.Create(ctx, key, obj, out, ttl)
+		return c.delegate.Create(ctx, key, obj, out, ttl)
 	})
 }
 
@@ -48,7 +78,7 @@ func (c *retryClient) Create(ctx context.Context, key string, obj, out runtime.O
 // If key didn't exist, it will return NotFound storage error.
 func (c *retryClient) Delete(ctx context.Context, key string, out runtime.Object, preconditions *storage.Preconditions, validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions) error {
 	return OnError(ctx, DefaultRetry, IsRetriableErrorOnWrite, func() error {
-		return c.Interface.Delete(ctx, key, out, preconditions, validateDeletion, cachedExistingObject, opts)
+		return c.delegate.Delete(ctx, key, out, preconditions, validateDeletion, cachedExistingObject, opts)
 	})
 }
 
@@ -63,7 +93,7 @@ func (c *retryClient) Watch(ctx context.Context, key string, opts storage.ListOp
 	var ret watch.Interface
 	err := OnError(ctx, DefaultRetry, IsRetriableErrorOnRead, func() error {
 		var innerErr error
-		ret, innerErr = c.Interface.Watch(ctx, key, opts)
+		ret, innerErr = c.delegate.Watch(ctx, key, opts)
 		return innerErr
 	})
 	return ret, err
@@ -76,7 +106,7 @@ func (c *retryClient) Watch(ctx context.Context, key string, opts storage.ListOp
 // match 'opts.ResourceVersion' according 'opts.ResourceVersionMatch'.
 func (c *retryClient) Get(ctx context.Context, key string, opts storage.GetOptions, objPtr runtime.Object) error {
 	return OnError(ctx, DefaultRetry, IsRetriableErrorOnRead, func() error {
-		return c.Interface.Get(ctx, key, opts, objPtr)
+		return c.delegate.Get(ctx, key, opts, objPtr)
 	})
 }
 
@@ -88,7 +118,7 @@ func (c *retryClient) Get(ctx context.Context, key string, opts storage.GetOptio
 // match 'opts.ResourceVersion' according 'opts.ResourceVersionMatch'.
 func (c *retryClient) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
 	return OnError(ctx, DefaultRetry, IsRetriableErrorOnRead, func() error {
-		return c.Interface.GetList(ctx, key, opts, listObj)
+		return c.delegate.GetList(ctx, key, opts, listObj)
 	})
 }
 
@@ -129,7 +159,7 @@ func (c *retryClient) GetList(ctx context.Context, key string, opts storage.List
 func (c *retryClient) GuaranteedUpdate(ctx context.Context, key string, destination runtime.Object, ignoreNotFound bool,
 	preconditions *storage.Preconditions, tryUpdate storage.UpdateFunc, cachedExistingObject runtime.Object) error {
 	return OnError(ctx, DefaultRetry, IsRetriableErrorOnWrite, func() error {
-		return c.Interface.GuaranteedUpdate(ctx, key, destination, ignoreNotFound, preconditions, tryUpdate, cachedExistingObject)
+		return c.delegate.GuaranteedUpdate(ctx, key, destination, ignoreNotFound, preconditions, tryUpdate, cachedExistingObject)
 	})
 }
 

--- a/vendor/k8s.io/apiserver/pkg/util/webhook/webhook.go
+++ b/vendor/k8s.io/apiserver/pkg/util/webhook/webhook.go
@@ -83,6 +83,7 @@ func NewGenericWebhook(scheme *runtime.Scheme, codecFactory serializer.CodecFact
 	clientConfig := rest.CopyConfig(config)
 
 	codec := codecFactory.LegacyCodec(groupVersions...)
+	clientConfig.ContentType = runtime.ContentTypeJSON
 	clientConfig.ContentConfig.NegotiatedSerializer = serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{Serializer: codec})
 
 	clientConfig.Wrap(x509metrics.NewDeprecatedCertificateRoundTripperWrapperConstructor(

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1401,7 +1401,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/apiserver v0.33.3 => github.com/openshift/kubernetes-apiserver v0.0.0-20250827071042-b0ff18f3664f
+# k8s.io/apiserver v0.33.3 => github.com/openshift/kubernetes-apiserver v0.0.0-20250917144435-182485d204aa
 ## explicit; go 1.24.0
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/configuration
@@ -2451,7 +2451,7 @@ sigs.k8s.io/yaml/goyaml.v3
 # k8s.io/api => k8s.io/api v0.33.3
 # k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.33.3
 # k8s.io/apimachinery => k8s.io/apimachinery v0.33.3
-# k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20250827071042-b0ff18f3664f
+# k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20250917144435-182485d204aa
 # k8s.io/cli-runtime => k8s.io/cli-runtime v0.33.3
 # k8s.io/client-go => k8s.io/client-go v0.33.3
 # k8s.io/cloud-provider => k8s.io/cloud-provider v0.33.3


### PR DESCRIPTION
Includes fixes for missing etcd retries of "GetCurrentResourceVersion" and for webhook client config content type mismatches.