### PR TITLE
NO-JIRA: route: Update OWNERS

### DIFF
--- a/pkg/route/OWNERS
+++ b/pkg/route/OWNERS
@@ -1,16 +1,29 @@
 reviewers:
-  - smarterclayton
-  - pweil-
-  - imcsk8
   - knobunc
-  - ironcladlou
-  - pecameron
-  - pravisankar
-  - rajatchopra
-  - jacobtanenbaum
+  - Miciah
+  - alebedev87
+  - rikatz
+  - candita
+  - rfredette
+  - gcs278
+  - davidesalerno
+  - bentito
+  - Thealisyed
+  - grzpiotrowski
 approvers:
+  - knobunc
+  - Miciah
+  - alebedev87
+  - rikatz
+  - candita
+  - rfredette
+  - gcs278
+  - davidesalerno
+  - bentito
+  - Thealisyed
+  - grzpiotrowski
+emeritus_approvers:
   - smarterclayton
   - pweil-
-  - knobunc
-  - ironcladlou
   - rajatchopra
+  - ironcladlou


### PR DESCRIPTION
- OpenShift Ingress&DNS team added as reviewers and approvers.
- `smarterclayton`, `pweil`, `rajatchopra` and `ironcladlou` moved to emeritus approvers.
- `imcsk8`,`pravisankar` and `pecameron` removed from reviewers because they left Red Hat.
- `jacobtanenbaum` removed from reviewers (not OpenShift Ingress&DNS team).