### PR TITLE
[release-4.19] OCPBUGS-61662: Add API validation to reject # or whitespace in spec.path

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/openshift-apiserver
 
-go 1.22.0
+go 1.23
 
-toolchain go1.22.1
+toolchain go1.23.0
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/hack/update-generated-conversions.sh
+++ b/hack/update-generated-conversions.sh
@@ -50,6 +50,8 @@ ALL_PEERS=(
 sed -i "s/$K8S_TAG/$TEMP_TAG/g" "$PATH_TO_FILE"
 
 echo "Generating conversions"
+# conversion-gen expects the pre-1.23 go/types alias behavior in Kubernetes 1.31 (https://go.dev/doc/go1.23#gotypespkggotypes)
+GODEBUG=gotypesalias=0 \
 ${GOPATH}/bin/conversion-gen "${ALL_FQ_APIS[@]}" --extra-peer-dirs $(codegen::join , "${ALL_PEERS[@]}") --output-file zz_generated.conversion.go --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.txt --v=8 "$@"
 
 # Restore the build tag back to the original one

--- a/hack/update-generated-openapi.sh
+++ b/hack/update-generated-openapi.sh
@@ -39,6 +39,8 @@ APIEXTENSIONS_INPUT_DIRS=(
 function join { local IFS="$1"; shift; echo "$*"; }
 
 echo "Generating origin openapi"
+# conversion-gen expects the pre-1.23 go/types alias behavior in Kubernetes 1.31 (https://go.dev/doc/go1.23#gotypespkggotypes)
+GODEBUG=gotypesalias=0 \
 ${GOPATH}/bin/openapi-gen \
   --output-file zz_generated.openapi.go \
   --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.txt \

--- a/images/Dockerfile.rhel
+++ b/images/Dockerfile.rhel
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-apiserver
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/openshift-apiserver/openshift-apiserver /usr/bin/
 ENTRYPOINT ["/usr/bin/openshift-apiserver"]
 LABEL io.k8s.display-name="OpenShift API Server Command" \


### PR DESCRIPTION
Replacement command used:
go mod edit --replace=github.com/openshift/library-go=github.com/openshift-cherrypick-robot/library-go@cd876ac95495b21b4443029b187dec745aed3fa2

go mod tidy