### PR TITLE
NO-JIRA: Created an OWNERS file for the tests-extension directory for separate ote scaffold

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,0 +1,17 @@
+reviewers:
+  - p0lyn0mial
+  - benluddy
+  - sanchezl
+  - dgrisonnet
+  - xingxingxia
+  - wangke19
+  - gangwgr
+approvers:
+  - p0lyn0mial
+  - benluddy
+  - sanchezl
+  - dgrisonnet
+  - xingxingxia
+  - wangke19
+  - gangwgr
+component: openshift-apiserver-tests


### PR DESCRIPTION
Plan to seperate OpenShift Test Extension (OTE) scaffolding for Openshift Apiserver, just like PR https://github.com/openshift/service-ca-operator/pull/283.
- Sets a specific component name (service-ca-tests) to distinguish it from the main service-ca component
- Follows the standard OpenShift OWNERS file format with reviewers and approvers sections
- Allows independent work on the tests-extension directory while maintaining proper review oversight