### PR TITLE
NO-JIRA: add .0 to go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/openshift/openshift-apiserver
 
 go 1.23.0
 
-toolchain go1.23.0
-
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/containers/image/v5 v5.24.3


### PR DESCRIPTION
Konflux expects go version to have .z. Task succeeded with [test build](https://art-jenkins.apps.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/aos-cd-builds/job/build%252Focp4-konflux/21033/console) (ART internal)

Caused due to https://github.com/openshift/openshift-apiserver/commit/177f6353629330d21e2c64001922c116b4b620f6