### PR TITLE
[release-4.18] OCPBUGS-74234: Bump library-go for route path validation fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/openshift/apiserver-library-go v0.0.0-20241021160823-f6d544efa1ab
 	github.com/openshift/build-machinery-go v0.0.0-20240613134303-8359781da660
 	github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f
-	github.com/openshift/library-go v0.0.0-20241107160307-0064ad7bd060
+	github.com/openshift/library-go v0.0.0-20260212164628-0c0d954931bf
 	github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/openshift/docker-distribution/v3 v3.0.0-20240215131201-6b2f5d2f1f43 h
 github.com/openshift/docker-distribution/v3 v3.0.0-20240215131201-6b2f5d2f1f43/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
 github.com/openshift/kubernetes-apiserver v0.0.0-20251107140821-cc544b99ea16 h1:dgaMnqHo8xhf8uc26GOojL15xr/XV5TmUZ6aaQZY5KM=
 github.com/openshift/kubernetes-apiserver v0.0.0-20251107140821-cc544b99ea16/go.mod h1:lzDhpeToamVZJmmFlaLwdYZwd7zB+WYRYIboqA1kGxM=
-github.com/openshift/library-go v0.0.0-20241107160307-0064ad7bd060 h1:jiDC7d8d+jmjv2WfiMY0+Uf55q11MGyYkGGqXnfqWTU=
-github.com/openshift/library-go v0.0.0-20241107160307-0064ad7bd060/go.mod h1:9B1MYPoLtP9tqjWxcbUNVpwxy68zOH/3EIP6c31dAM0=
+github.com/openshift/library-go v0.0.0-20260212164628-0c0d954931bf h1:MTg6bXmGUJZORHjxeJCWHKXrEnEYhzSo3ESkAfRBmys=
+github.com/openshift/library-go v0.0.0-20260212164628-0c0d954931bf/go.mod h1:l/3SegTa9x+ry2J213bh7+DBofXOOvdrqU4JC9ktJa0=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d h1:fLITXDjxMSvUDjnXs/zljIWktbST9+Om8XbrmmM7T4I=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d/go.mod h1:LJM49W8fBVSj+rvcopJZu9mgH5Tx6HwLHySIYeGeu4k=
 github.com/openshift/runtime-utils v0.0.0-20230921210328-7bdb5b9c177b h1:oXzC1N6E9gw76/WH2gEA8GEHvuq09wuVQ9GoCuR8GF4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -600,7 +600,7 @@ github.com/openshift/client-go/user/clientset/versioned/fake
 github.com/openshift/client-go/user/clientset/versioned/scheme
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1
 github.com/openshift/client-go/user/clientset/versioned/typed/user/v1/fake
-# github.com/openshift/library-go v0.0.0-20241107160307-0064ad7bd060
+# github.com/openshift/library-go v0.0.0-20260212164628-0c0d954931bf
 ## explicit; go 1.22.0
 github.com/openshift/library-go/pkg/apiserver/admission/admissionregistrationtesting
 github.com/openshift/library-go/pkg/apiserver/admission/admissionrestconfig


### PR DESCRIPTION
## Summary
This PR backports the route path validation fix from release-4.19 PR https://github.com/openshift/openshift-apiserver/pull/576 to release-4.18. The fix rejects routes with '#' or whitespace in spec.path.

Why this PR differs from its parent PR https://github.com/openshift/openshift-apiserver/pull/576 (release-4.19):

For release-4.19, there was a Kubernetes version difference between
openshift-apiserver and library-go which made bumping library-go difficult.
As a result, PR https://github.com/openshift/openshift-apiserver/pull/576 copied the validatePath function directly into
openshift-apiserver's validation.go rather than bumping the dependency.

For release-4.18, the Kubernetes versions matched between the repos, so
we could bump library-go directly:
1. First, the validation was cherry-picked to library-go release-4.18
   via PR github.com/https://github.com/openshift/library-go/pull/2117
2. Then this PR bumps library-go to include that fix

To maintain consistency with PR https://github.com/openshift/openshift-apiserver/pull/576 and ensure the validation code
structure matches across branches, this PR also adds the same
validatePath function to pkg/route/apis/route/validation/validation.go.

Assisted with Claude
