### PR TITLE
NO-JIRA: watchlist: Fall back to default listing

### DIFF
--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -110,6 +110,12 @@ func (s *REST) Watch(ctx context.Context, options *metainternal.ListOptions) (wa
 		return nil, fmt.Errorf("no user")
 	}
 
+	// Reject WatchList requests: the custom userProjectWatcher doesn't support bookmark events.
+	// Client-go will automatically fall back to legacy LIST+WATCH behavior.
+	if options != nil && options.SendInitialEvents != nil && *options.SendInitialEvents {
+		return nil, fmt.Errorf("sendInitialEvents is not supported for project watches")
+	}
+
 	includeAllExistingProjects := (options != nil) && options.ResourceVersion == "0"
 
 	allowedNamespaces, err := scope.ScopesToVisibleNamespaces(userInfo.GetExtra()[authorizationapi.ScopesKey], s.authCache.GetClusterRoleLister(), true)

--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -113,7 +113,7 @@ func (s *REST) Watch(ctx context.Context, options *metainternal.ListOptions) (wa
 	// Reject WatchList requests: the custom userProjectWatcher doesn't support bookmark events.
 	// Client-go will automatically fall back to legacy LIST+WATCH behavior.
 	if options != nil && options.SendInitialEvents != nil && *options.SendInitialEvents {
-		return nil, fmt.Errorf("sendInitialEvents is not supported for project watches")
+		return nil, kerrors.NewBadRequest("the project resource does not support the sendInitialEvents parameter")
 	}
 
 	includeAllExistingProjects := (options != nil) && options.ResourceVersion == "0"


### PR DESCRIPTION
Currently any watch/list call to Project resource hangs and times out eventually due to the lack of support of WatchList feature gate. If it returns error when this kind of request comes in, client-go will fall back to previous behavior. So that this PR catches the WatchList request and returns error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Watch requests that include SendInitialEvents are now rejected with the error: "the project resource does not support the sendInitialEvents parameter", preventing unsupported bookmark-style initial events from proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->