### PR TITLE
NO-JIRA: Send bookmark events to be compatible with watchlist

### DIFF
--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -112,13 +112,18 @@ func (s *REST) Watch(ctx context.Context, options *metainternal.ListOptions) (wa
 
 	includeAllExistingProjects := (options != nil) && options.ResourceVersion == "0"
 
+	sendInitialEventsBookmark := options != nil && options.SendInitialEvents != nil && *options.SendInitialEvents
+	if sendInitialEventsBookmark {
+		includeAllExistingProjects = true
+	}
+
 	allowedNamespaces, err := scope.ScopesToVisibleNamespaces(userInfo.GetExtra()[authorizationapi.ScopesKey], s.authCache.GetClusterRoleLister(), true)
 	if err != nil {
 		return nil, err
 	}
 
 	m := projectutil.MatchProject(apihelpers.InternalListOptionsToSelectors(options))
-	watcher := projectauth.NewUserProjectWatcher(userInfo, allowedNamespaces, s.projectCache, s.authCache, includeAllExistingProjects, m)
+	watcher := projectauth.NewUserProjectWatcher(userInfo, allowedNamespaces, s.projectCache, s.authCache, includeAllExistingProjects, sendInitialEventsBookmark, m)
 	s.authCache.AddWatcher(watcher)
 
 	go watcher.Watch()

--- a/pkg/project/auth/watch.go
+++ b/pkg/project/auth/watch.go
@@ -64,6 +64,10 @@ type userProjectWatcher struct {
 	initialProjects []corev1.Namespace
 	// knownProjects maps name to resourceVersion
 	knownProjects map[string]string
+	// sendInitialEventsBookmark indicates whether to send a bookmark after initial events
+	sendInitialEventsBookmark bool
+	// initialEventsResourceVersion is the cluster ResourceVersion at watch initialization
+	initialEventsResourceVersion string
 }
 
 var (
@@ -72,7 +76,7 @@ var (
 	watchChannelHWM kstorage.HighWaterMark
 )
 
-func NewUserProjectWatcher(user user.Info, visibleNamespaces sets.String, projectCache *projectcache.ProjectCache, authCache WatchableCache, includeAllExistingProjects bool, predicate kstorage.SelectionPredicate) *userProjectWatcher {
+func NewUserProjectWatcher(user user.Info, visibleNamespaces sets.String, projectCache *projectcache.ProjectCache, authCache WatchableCache, includeAllExistingProjects bool, sendInitialEventsBookmark bool, predicate kstorage.SelectionPredicate) *userProjectWatcher {
 	namespaces, _ := authCache.List(user, labels.Everything())
 	knownProjects := map[string]string{}
 	for _, namespace := range namespaces.Items {
@@ -94,17 +98,22 @@ func NewUserProjectWatcher(user user.Info, visibleNamespaces sets.String, projec
 		outgoing:      make(chan watch.Event),
 		userStop:      make(chan struct{}),
 
-		projectCache:    projectCache,
-		authCache:       authCache,
-		initialProjects: initialProjects,
-		knownProjects:   knownProjects,
+		projectCache:                 projectCache,
+		authCache:                    authCache,
+		initialProjects:              initialProjects,
+		knownProjects:                knownProjects,
+		sendInitialEventsBookmark:    sendInitialEventsBookmark,
+		initialEventsResourceVersion: namespaces.ResourceVersion,
 	}
 	w.emit = func(e watch.Event) {
-		// if dealing with project events, ensure that we only emit events for projects
-		// that match the field or label selector specified by a consumer
-		if project, ok := e.Object.(*projectapi.Project); ok {
-			if matches, err := predicate.Matches(project); err != nil || !matches {
-				return
+		// BOOKMARK events must pass through without predicate filtering
+		if e.Type != watch.Bookmark {
+			// if dealing with project events, ensure that we only emit events for projects
+			// that match the field or label selector specified by a consumer
+			if project, ok := e.Object.(*projectapi.Project); ok {
+				if matches, err := predicate.Matches(project); err != nil || !matches {
+					return
+				}
 			}
 		}
 
@@ -194,7 +203,6 @@ func (w *userProjectWatcher) Watch() {
 	}()
 	defer utilruntime.HandleCrash()
 
-	// start by emitting all the `initialProjects`
 	for i := range w.initialProjects {
 		// keep this check here to sure we don't keep this open in the case of failures
 		select {
@@ -211,6 +219,20 @@ func (w *userProjectWatcher) Watch() {
 		w.emit(watch.Event{
 			Type:   watch.Added,
 			Object: namespaceInternal,
+		})
+	}
+
+	// Send initial-events-end bookmark to support WatchList feature gate
+	if w.sendInitialEventsBookmark {
+		bookmarkProject := &projectapi.Project{}
+		bookmarkProject.ResourceVersion = w.initialEventsResourceVersion
+		if bookmarkProject.Annotations == nil {
+			bookmarkProject.Annotations = make(map[string]string)
+		}
+		bookmarkProject.Annotations[metav1.InitialEventsAnnotationKey] = "true"
+		w.emit(watch.Event{
+			Type:   watch.Bookmark,
+			Object: bookmarkProject,
 		})
 	}
 

--- a/pkg/project/auth/watch_test.go
+++ b/pkg/project/auth/watch_test.go
@@ -41,7 +41,7 @@ func newTestWatcher(username string, groups []string, predicate storage.Selectio
 	stopCh := make(chan struct{})
 	go projectCache.Run(stopCh)
 
-	return NewUserProjectWatcher(&user.DefaultInfo{Name: username, Groups: groups}, sets.NewString("*"), projectCache, fakeAuthCache, false, predicate), fakeAuthCache, stopCh
+	return NewUserProjectWatcher(&user.DefaultInfo{Name: username, Groups: groups}, sets.NewString("*"), projectCache, fakeAuthCache, false, false, predicate), fakeAuthCache, stopCh
 }
 
 type fakeAuthCache struct {


### PR DESCRIPTION
When request contains SendInitialEvents: true option (WatchList feature gate can send it), we need to emit all the projects just like we do when resourceVersion: 0. Additionally, in order to be compatible with WatchList feature gate, watch handler must return special bookmark event to signal that all the previous projects are emitted. 

This PR makes changes to make project watch handle compatible with WatchList.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional initial-events bookmark for project watches to mark completion of initial event delivery.

* **Updates**
  * Bookmark notifications now bypass normal filters so clients reliably detect initial-events completion.
  * Watcher records the cluster resource version and emits a clear end-of-initial-events bookmark for improved synchronization and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->