### PR TITLE
OCPBUGS-78596: Fix image reference in TestImageStreamImportQuayIO [release-4.13] 

### DIFF
--- a/pkg/image/apiserver/importer/import_integration_test.go
+++ b/pkg/image/apiserver/importer/import_integration_test.go
@@ -94,10 +94,11 @@ func TestImageStreamImportQuayIO(t *testing.T) {
 	importCtx := importer.NewStaticCredentialsContext(rt, nil, nil)
 
 	repositoryName := quayRegistryName + "/coreos/etcd"
+	tag := "v3.4.37"
 	imports := &imageapi.ImageStreamImport{
 		Spec: imageapi.ImageStreamImportSpec{
 			Images: []imageapi.ImageImportSpec{
-				{From: kapi.ObjectReference{Kind: "DockerImage", Name: repositoryName}},
+				{From: kapi.ObjectReference{Kind: "DockerImage", Name: fmt.Sprintf("%s:%s", repositoryName, tag)}},
 			},
 		},
 	}


### PR DESCRIPTION
quay.io/coreos/etcd:latest is gone, use a different tag instead.
cherry-picked using claude