### PR TITLE
NO-JIRA: Add control-plane-approvers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,7 @@
 reviewers:
-  - p0lyn0mial
-  - benluddy
+  - control-plane-approvers
   - sanchezl
-  - dgrisonnet
 approvers:
-  - p0lyn0mial
-  - benluddy
+  - control-plane-approvers
   - sanchezl
-  - dgrisonnet
 component: openshift-apiserver

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+aliases:
+  control-plane-approvers:
+    - ardaguclu
+    - atiratree
+    - benluddy
+    - bertinatto
+    - everettraven
+    - flavianmissi
+    - gangwgr
+    - ingvagabund
+    - kaleemsiddiqu
+    - p0lyn0mial
+    - rh-roman
+    - ricardomaraschini
+    - tjungblu
+    - xueqzhan


### PR DESCRIPTION
Add control-plane-approvers to OWNERS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reviewer and approver team assignments for the OpenShift API Server component to reflect current organizational structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->