### PR TITLE
OCPBUGS-38120: Ensure Project delete requests are passed through admission

### DIFF
--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -214,5 +214,26 @@ func (s *REST) Delete(ctx context.Context, name string, objectFunc rest.Validate
 	if options != nil {
 		opts = *options
 	}
+	if objectFunc != nil {
+		obj, err := s.Get(ctx, name, &metav1.GetOptions{})
+		if err != nil {
+			return nil, false, err
+		}
+		projectObj, ok := obj.(*projectapi.Project)
+		if !ok || projectObj == nil {
+			return nil, false, fmt.Errorf("not a project: %#v", obj)
+		}
+
+		// Make sure the object hasn't changed between Get and Delete - pass UID and RV to delete options
+		if opts.Preconditions == nil {
+			opts.Preconditions = &metav1.Preconditions{}
+		}
+		opts.Preconditions.UID = &projectObj.UID
+		opts.Preconditions.ResourceVersion = &projectObj.ResourceVersion
+
+		if err := objectFunc(ctx, obj); err != nil {
+			return nil, false, err
+		}
+	}
 	return &metav1.Status{Status: metav1.StatusSuccess}, false, s.client.Delete(ctx, name, opts)
 }

--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -255,7 +255,7 @@ func (s *REST) Delete(ctx context.Context, name string, objectFunc rest.Validate
 		Factor:   2,
 	}
 	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
-		project, err := s.getProjectForDeletion(ctx, name, &opts)
+		project, err := s.getProjectForDeletion(ctx, name)
 		if err != nil {
 			lastErr = fmt.Errorf("getting project for deletion: %w", err)
 			return false, nil
@@ -263,8 +263,7 @@ func (s *REST) Delete(ctx context.Context, name string, objectFunc rest.Validate
 
 		// Do not retry if the deletion preconditions are invalid because
 		// the request will always fail.
-		err = validateDeletePreconditionsForProject(project, &opts)
-		if err != nil {
+		if err := validateDeletePreconditionsForProject(project, &opts); err != nil {
 			return false, fmt.Errorf("validating preconditions: %w", err)
 		}
 
@@ -279,7 +278,7 @@ func (s *REST) Delete(ctx context.Context, name string, objectFunc rest.Validate
 		// If the user *did* supply preconditions, we already inherited them and
 		// should continue using them.
 		deleteOpts := opts
-		userProvidedPreconditions := (options != nil && options.Preconditions != nil)
+		userProvidedPreconditions := opts.Preconditions != nil
 		if !userProvidedPreconditions {
 			deleteOpts.Preconditions = &metav1.Preconditions{
 				UID:             &project.UID,
@@ -307,7 +306,7 @@ func (s *REST) Delete(ctx context.Context, name string, objectFunc rest.Validate
 	return &metav1.Status{Status: metav1.StatusSuccess}, false, nil
 }
 
-func (s *REST) getProjectForDeletion(ctx context.Context, name string, deleteOptions *metav1.DeleteOptions) (*projectapi.Project, error) {
+func (s *REST) getProjectForDeletion(ctx context.Context, name string) (*projectapi.Project, error) {
 	getOpts := metav1.GetOptions{}
 
 	obj, err := s.Get(ctx, name, &getOpts)

--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -322,17 +322,27 @@ func (s *REST) getProjectForDeletion(ctx context.Context, name string) (*project
 	return projectObj, nil
 }
 
-func validateDeletePreconditionsForProject(project *projectapi.Project, deleteOptions *metav1.DeleteOptions) error {
+func validateDeletePreconditionsForProject(proj *projectapi.Project, deleteOptions *metav1.DeleteOptions) error {
 	if deleteOptions == nil || deleteOptions.Preconditions == nil {
 		return nil
 	}
 
-	if deleteOptions.Preconditions.UID != nil && project.UID != *deleteOptions.Preconditions.UID {
-		return fmt.Errorf("uid precondition %q does not match project uid %q", *deleteOptions.Preconditions.UID, project.UID)
+	if deleteOptions.Preconditions.UID != nil && proj.UID != *deleteOptions.Preconditions.UID {
+		return kerrors.NewConflict(
+			project.Resource("project"),
+			proj.Name,
+			fmt.Errorf("precondition failed: uid %q does not match current uid %q",
+				*deleteOptions.Preconditions.UID, proj.UID),
+		)
 	}
 
-	if deleteOptions.Preconditions.ResourceVersion != nil && project.ResourceVersion != *deleteOptions.Preconditions.ResourceVersion {
-		return fmt.Errorf("resourceVersion precondition %q does not match project resourceVersion %q", *deleteOptions.Preconditions.ResourceVersion, project.ResourceVersion)
+	if deleteOptions.Preconditions.ResourceVersion != nil && proj.ResourceVersion != *deleteOptions.Preconditions.ResourceVersion {
+		return kerrors.NewConflict(
+			project.Resource("project"),
+			proj.Name,
+			fmt.Errorf("precondition failed: resourceVersion %q does not match current resourceVersion %q",
+				*deleteOptions.Preconditions.ResourceVersion, proj.ResourceVersion),
+		)
 	}
 
 	return nil

--- a/pkg/project/apiserver/registry/project/proxy/proxy_test.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy_test.go
@@ -2,18 +2,23 @@ package proxy
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 
 	oapi "github.com/openshift/openshift-apiserver/pkg/api"
 	projectapi "github.com/openshift/openshift-apiserver/pkg/project/apis/project"
@@ -81,7 +86,7 @@ func TestCreateInvalidProject(t *testing.T) {
 			Annotations: map[string]string{oapi.OpenShiftDisplayName: "h\t\ni"},
 		},
 	}, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
-	if !errors.IsInvalid(err) {
+	if !kerrors.IsInvalid(err) {
 		t.Errorf("Expected 'invalid' error, got %v", err)
 	}
 }
@@ -139,46 +144,360 @@ func TestGetProjectOK(t *testing.T) {
 	}
 }
 
-func TestDeleteProject(t *testing.T) {
-	mockClient := &fake.Clientset{}
-	storage := REST{
-		client: mockClient.CoreV1().Namespaces(),
-	}
-	obj, _, err := storage.Delete(apirequest.NewContext(), "foo", nil, &metav1.DeleteOptions{})
-	if obj == nil {
-		t.Error("Unexpected nil obj")
-	}
-	if err != nil {
-		t.Errorf("Unexpected non-nil error: %#v", err)
-	}
-	status, ok := obj.(*metav1.Status)
-	if !ok {
-		t.Errorf("Expected status type, got: %#v", obj)
-	}
-	if status.Status != metav1.StatusSuccess {
-		t.Errorf("Expected status=success, got: %#v", status)
-	}
-	if len(mockClient.Actions()) != 1 {
-		t.Errorf("Expected client action for delete, got %v", mockClient.Actions())
-	}
-	if !mockClient.Actions()[0].Matches("delete", "namespaces") {
-		t.Errorf("Expected call to delete-namespace, got %#v", mockClient.Actions()[0])
+type objectValidator struct {
+	called     int
+	objectFunc rest.ValidateObjectFunc
+}
+
+func (ov *objectValidator) ValidateObjectFunc() rest.ValidateObjectFunc {
+	return func(ctx context.Context, obj runtime.Object) error {
+		ov.called++
+		return ov.objectFunc(ctx, obj)
 	}
 }
 
-func TestDeleteProjectValidation(t *testing.T) {
-	mockClient := &fake.Clientset{}
-	storage := REST{
-		client: mockClient.CoreV1().Namespaces(),
-	}
-	validationCalled := false
-	validationFunc := func(ctx context.Context, obj runtime.Object) error {
-		validationCalled = true
-		return nil
+type reactionFunc func(called int) (runtime.Object, error)
+
+type reactor struct {
+	called        int
+	expectedCalls int
+	verb          string
+	resource      string
+	reaction      reactionFunc
+}
+
+func (r *reactor) Handles(action ktesting.Action) bool {
+	if !(r.verb == "*" || r.verb == action.GetVerb()) {
+		return false
 	}
 
-	storage.Delete(apirequest.NewContext(), "foo", validationFunc, &metav1.DeleteOptions{})
-	if !validationCalled {
-		t.Errorf("Expected validation function to be called")
+	actionableRes := action.GetResource().Resource
+	if action.GetSubresource() != "" {
+		actionableRes = fmt.Sprintf("%s/%s", action.GetResource().Resource, action.GetSubresource())
+	}
+
+	if !(r.resource == "*" || r.resource == actionableRes) {
+		return false
+	}
+
+	return true
+}
+
+func (r *reactor) React(action ktesting.Action) (bool, runtime.Object, error) {
+	var out runtime.Object
+	var err error
+	if r.Handles(action) {
+		out, err = r.reaction(r.called)
+		r.called++
+	}
+
+	return r.Handles(action), out, err
+}
+
+func newReactor(verb, resource string, reaction reactionFunc, expectedCalls int) *reactor {
+	return &reactor{
+		verb:          verb,
+		resource:      resource,
+		reaction:      reaction,
+		expectedCalls: expectedCalls,
+	}
+}
+
+func TestDeleteProject(t *testing.T) {
+	type testcase struct {
+		name                    string
+		reactors                []*reactor
+		objectValidator         *objectValidator
+		options                 *metav1.DeleteOptions
+		expectedStatus          *metav1.Status
+		expectedErr             error
+		expectedValidationCalls int
+	}
+
+	testcases := []testcase{
+		{
+			name:           "no validation, no options, request succeeds",
+			expectedStatus: &metav1.Status{Status: metav1.StatusSuccess},
+		},
+		{
+			name: "has validation, getting project succeeds, no options, validation successful, validation called once, request succeeds",
+			objectValidator: &objectValidator{
+				objectFunc: func(ctx context.Context, obj runtime.Object) error {
+					return nil
+				},
+			},
+			expectedStatus:          &metav1.Status{Status: metav1.StatusSuccess},
+			expectedValidationCalls: 1,
+		},
+		{
+			name: "has validation, getting project succeeds, no options, validation fails, validation retried, request fails",
+			objectValidator: &objectValidator{
+				objectFunc: func(ctx context.Context, obj runtime.Object) error {
+					return errors.New("boom")
+				},
+			},
+			expectedStatus:          &metav1.Status{Status: metav1.StatusFailure},
+			expectedValidationCalls: 10,
+			expectedErr:             errors.New("validating project: boom"),
+		},
+		{
+			name: "has validation, getting project perma-fails with non-terminal error, no options, validation never called, request fails",
+			reactors: []*reactor{
+				newReactor(
+					"get",
+					"namespaces",
+					func(called int) (runtime.Object, error) {
+						return nil, errors.New("boom")
+					},
+					10,
+				),
+			},
+			objectValidator: &objectValidator{
+				objectFunc: func(ctx context.Context, obj runtime.Object) error {
+					return nil
+				},
+			},
+			expectedStatus: &metav1.Status{Status: metav1.StatusFailure},
+			expectedErr:    errors.New("getting project for deletion: unable to get project: boom"),
+		},
+		{
+			name: "has validation, getting project transient failure, no options, validation called once, validation successful, request succeeds",
+			reactors: []*reactor{
+				newReactor(
+					"get",
+					"namespaces",
+					func(called int) (runtime.Object, error) {
+						if called < 1 {
+							return nil, errors.New("transient")
+						}
+
+						return nil, nil
+					},
+					2,
+				),
+			},
+			objectValidator: &objectValidator{
+				objectFunc: func(ctx context.Context, obj runtime.Object) error {
+					return nil
+				},
+			},
+			expectedStatus:          &metav1.Status{Status: metav1.StatusSuccess},
+			expectedValidationCalls: 1,
+		},
+		{
+			name: "has validation, getting project succeeds, uid precondition validation failed, validation not called, request fails",
+			reactors: []*reactor{
+				newReactor(
+					"get",
+					"namespaces",
+					func(called int) (runtime.Object, error) {
+						namespace := &corev1.Namespace{
+							ObjectMeta: metav1.ObjectMeta{
+								UID:  types.UID("two"),
+								Name: "test",
+							},
+						}
+						return namespace, nil
+					},
+					1,
+				),
+			},
+			objectValidator: &objectValidator{
+				objectFunc: func(ctx context.Context, obj runtime.Object) error {
+					return nil
+				},
+			},
+			options: &metav1.DeleteOptions{
+				Preconditions: &metav1.Preconditions{
+					UID:             ptr.To(types.UID("one")),
+					ResourceVersion: ptr.To("12345"),
+				},
+			},
+			expectedStatus: &metav1.Status{Status: metav1.StatusFailure},
+			expectedErr:    errors.New("validating preconditions: uid precondition \"one\" does not match project uid \"two\""),
+		},
+		{
+			name: "has validation, getting project succeeds, resourceVersion precondition validation failed, validation not called, request fails",
+			reactors: []*reactor{
+				newReactor(
+					"get",
+					"namespaces",
+					func(called int) (runtime.Object, error) {
+						namespace := &corev1.Namespace{
+							ObjectMeta: metav1.ObjectMeta{
+								UID:             types.UID("one"),
+								Name:            "test",
+								ResourceVersion: "12347",
+							},
+						}
+						return namespace, nil
+					},
+					1,
+				),
+			},
+			objectValidator: &objectValidator{
+				objectFunc: func(ctx context.Context, obj runtime.Object) error {
+					return nil
+				},
+			},
+			options: &metav1.DeleteOptions{
+				Preconditions: &metav1.Preconditions{
+					UID:             ptr.To(types.UID("one")),
+					ResourceVersion: ptr.To("12345"),
+				},
+			},
+			expectedStatus: &metav1.Status{Status: metav1.StatusFailure},
+			expectedErr:    errors.New("validating preconditions: resourceVersion precondition \"12345\" does not match project resourceVersion \"12347\""),
+		},
+		{
+			name: "no validation, delete successful, request succeeds, no retries happen",
+			reactors: []*reactor{
+				newReactor(
+					"delete",
+					"namespaces",
+					func(called int) (runtime.Object, error) {
+						return nil, nil
+					},
+					1,
+				),
+			},
+			expectedStatus: &metav1.Status{Status: metav1.StatusSuccess},
+		},
+		{
+			name: "no validation, delete has initial conflict, request fails",
+			reactors: []*reactor{
+				newReactor(
+					"delete",
+					"namespaces",
+					func(called int) (runtime.Object, error) {
+						if called < 1 {
+							return nil, kerrors.NewConflict(corev1.Resource("namespaces"), "foo", errors.New("boom"))
+						}
+						return nil, nil
+					},
+					1,
+				),
+			},
+			expectedStatus: &metav1.Status{Status: metav1.StatusFailure},
+			expectedErr:    kerrors.NewConflict(corev1.Resource("namespaces"), "foo", errors.New("boom")),
+		},
+		{
+			name: "no validation, delete has non-conflict failure, request not retried, request fails",
+			reactors: []*reactor{
+				newReactor("delete", "namespaces", func(called int) (runtime.Object, error) {
+					return nil, errors.New("boom")
+				}, 1),
+			},
+			expectedStatus: &metav1.Status{Status: metav1.StatusFailure},
+			expectedErr:    errors.New("boom"),
+		},
+		{
+			name: "no validation, delete has persistent conflict failure, request not retried, request fails",
+			reactors: []*reactor{
+				newReactor("delete", "namespaces", func(called int) (runtime.Object, error) {
+					return nil, kerrors.NewConflict(corev1.Resource("namespaces"), "foo", errors.New("boom"))
+				}, 1),
+			},
+			expectedStatus: &metav1.Status{Status: metav1.StatusFailure},
+			expectedErr:    kerrors.NewConflict(corev1.Resource("namespaces"), "foo", errors.New("boom")),
+		},
+		{
+			name: "no validation, delete has persistent conflict failure, user supplied preconditions, no retry, request fails",
+			reactors: []*reactor{
+				newReactor("delete", "namespaces", func(called int) (runtime.Object, error) {
+					return nil, kerrors.NewConflict(corev1.Resource("namespaces"), "foo", errors.New("boom"))
+				}, 1),
+			},
+			options: &metav1.DeleteOptions{
+				Preconditions: &metav1.Preconditions{
+					UID:             ptr.To(types.UID("1234")),
+					ResourceVersion: ptr.To("1234"),
+				},
+			},
+			expectedStatus: &metav1.Status{Status: metav1.StatusFailure},
+			expectedErr:    kerrors.NewConflict(corev1.Resource("namespaces"), "foo", errors.New("boom")),
+		},
+		{
+			name: "validation, validation successful, delete has persistent conflict failure, user supplied preconditions, no retry, request fails",
+			reactors: []*reactor{
+				newReactor("get", "namespaces", func(called int) (runtime.Object, error) {
+					namespace := &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:             types.UID("1234"),
+							Name:            "test",
+							ResourceVersion: "1234",
+						},
+					}
+					return namespace, nil
+				}, 1),
+				newReactor("delete", "namespaces", func(called int) (runtime.Object, error) {
+					return nil, kerrors.NewConflict(corev1.Resource("namespaces"), "foo", errors.New("boom"))
+				}, 1),
+			},
+			objectValidator: &objectValidator{
+				objectFunc: func(ctx context.Context, obj runtime.Object) error {
+					return nil
+				},
+			},
+			options: &metav1.DeleteOptions{
+				Preconditions: &metav1.Preconditions{
+					UID:             ptr.To(types.UID("1234")),
+					ResourceVersion: ptr.To("1234"),
+				},
+			},
+			expectedStatus:          &metav1.Status{Status: metav1.StatusFailure},
+			expectedErr:             kerrors.NewConflict(corev1.Resource("namespaces"), "foo", errors.New("boom")),
+			expectedValidationCalls: 1,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			var validationFunc rest.ValidateObjectFunc
+			if tc.objectValidator != nil {
+				validationFunc = tc.objectValidator.ValidateObjectFunc()
+			}
+
+			client := &fake.Clientset{}
+			if len(tc.reactors) > 0 {
+				reactors := []ktesting.Reactor{}
+				for _, reactor := range tc.reactors {
+					reactors = append(reactors, reactor)
+				}
+				client.ReactionChain = reactors
+			}
+
+			storage := &REST{
+				client: client.CoreV1().Namespaces(),
+			}
+
+			obj, _, err := storage.Delete(apirequest.NewContext(), "foo", validationFunc, tc.options)
+			switch {
+			case err != nil && tc.expectedErr == nil:
+				t.Fatalf("received an unexpected error: %v", err)
+			case err == nil && tc.expectedErr != nil:
+				t.Fatalf("expected an error but did not receive one. expected error: %v", tc.expectedErr)
+			case err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error():
+				t.Fatalf("received error does not match expected error. expected error: %v , received error: %v", tc.expectedErr, err)
+			}
+
+			if tc.expectedStatus.Status != obj.(*metav1.Status).Status {
+				t.Fatalf("received an unexpected status. expected status: %v , received status: %v", tc.expectedStatus, obj.(*metav1.Status))
+			}
+
+			if tc.objectValidator != nil {
+				if tc.objectValidator.called != tc.expectedValidationCalls {
+					t.Fatalf("expected validation to be called %d times, but was called %d times", tc.expectedValidationCalls, tc.objectValidator.called)
+				}
+			}
+
+			if len(tc.reactors) > 0 {
+				for _, reactor := range tc.reactors {
+					if reactor.called != reactor.expectedCalls {
+						t.Fatalf("expected reaction for %q to be called %d times, but was called %d times", fmt.Sprintf("%s %s", reactor.verb, reactor.resource), reactor.expectedCalls, reactor.called)
+					}
+				}
+			}
+		})
 	}
 }

--- a/pkg/project/apiserver/registry/project/proxy/proxy_test.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy_test.go
@@ -21,6 +21,7 @@ import (
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 
+	"github.com/openshift/api/project"
 	oapi "github.com/openshift/openshift-apiserver/pkg/api"
 	projectapi "github.com/openshift/openshift-apiserver/pkg/project/apis/project"
 )
@@ -318,7 +319,12 @@ func TestDeleteProject(t *testing.T) {
 				},
 			},
 			expectedStatus: &metav1.Status{Status: metav1.StatusFailure},
-			expectedErr:    errors.New("validating preconditions: uid precondition \"one\" does not match project uid \"two\""),
+			expectedErr: fmt.Errorf("validating preconditions: %w",
+				kerrors.NewConflict(
+					project.Resource("project"),
+					"test",
+					fmt.Errorf("precondition failed: uid %q does not match current uid %q", "one", "two"),
+				)),
 		},
 		{
 			name: "has validation, getting project succeeds, resourceVersion precondition validation failed, validation not called, request fails",
@@ -351,7 +357,12 @@ func TestDeleteProject(t *testing.T) {
 				},
 			},
 			expectedStatus: &metav1.Status{Status: metav1.StatusFailure},
-			expectedErr:    errors.New("validating preconditions: resourceVersion precondition \"12345\" does not match project resourceVersion \"12347\""),
+			expectedErr: fmt.Errorf("validating preconditions: %w",
+				kerrors.NewConflict(
+					project.Resource("project"),
+					"test",
+					fmt.Errorf("precondition failed: resourceVersion %q does not match current resourceVersion %q", "12345", "12347"),
+				)),
 		},
 		{
 			name: "no validation, delete successful, request succeeds, no retries happen",

--- a/pkg/project/apiserver/registry/project/proxy/proxy_test.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -73,7 +74,7 @@ func TestCreateProjectBadObject(t *testing.T) {
 	if obj != nil {
 		t.Errorf("Expected nil, got %v", obj)
 	}
-	if strings.Index(err.Error(), "not a project:") == -1 {
+	if !strings.Contains(err.Error(), "not a project:") {
 		t.Errorf("Expected 'not an project' error, got %v", err)
 	}
 }
@@ -196,21 +197,24 @@ func (r *reactor) React(action ktesting.Action) (bool, runtime.Object, error) {
 
 func newReactor(verb, resource string, reaction reactionFunc, expectedCalls int) *reactor {
 	return &reactor{
-		verb:          verb,
-		resource:      resource,
-		reaction:      reaction,
+		verb:     verb,
+		resource: resource,
+		reaction: reaction,
+		// Use -1 to ignore
 		expectedCalls: expectedCalls,
 	}
 }
 
 func TestDeleteProject(t *testing.T) {
 	type testcase struct {
-		name                    string
-		reactors                []*reactor
-		objectValidator         *objectValidator
-		options                 *metav1.DeleteOptions
-		expectedStatus          *metav1.Status
-		expectedErr             error
+		name            string
+		ctxFunc         func() context.Context
+		reactors        []*reactor
+		objectValidator *objectValidator
+		options         *metav1.DeleteOptions
+		expectedStatus  *metav1.Status
+		expectedErr     error
+		// Use -1 to ignore
 		expectedValidationCalls int
 	}
 
@@ -382,6 +386,31 @@ func TestDeleteProject(t *testing.T) {
 			expectedErr:    kerrors.NewConflict(corev1.Resource("namespaces"), "foo", errors.New("boom")),
 		},
 		{
+			name: "has validation, auto-generated preconditions, delete has initial conflict then succeeds",
+			reactors: []*reactor{
+				newReactor("get", "namespaces", func(called int) (runtime.Object, error) {
+					// Return different ResourceVersion each time to simulate state change
+					return &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:             "1234",
+							ResourceVersion: fmt.Sprintf("%d", 100+called),
+						},
+					}, nil
+				}, 2),
+				newReactor("delete", "namespaces", func(called int) (runtime.Object, error) {
+					if called < 1 {
+						return nil, kerrors.NewConflict(corev1.Resource("namespaces"), "foo", errors.New("first delete conflicts"))
+					}
+					return nil, nil
+				}, 2),
+			},
+			objectValidator: &objectValidator{
+				objectFunc: func(ctx context.Context, obj runtime.Object) error { return nil },
+			},
+			expectedValidationCalls: 2, // Validation runs twice
+			expectedStatus:          &metav1.Status{Status: metav1.StatusSuccess},
+		},
+		{
 			name: "no validation, delete has non-conflict failure, request not retried, request fails",
 			reactors: []*reactor{
 				newReactor("delete", "namespaces", func(called int) (runtime.Object, error) {
@@ -449,6 +478,37 @@ func TestDeleteProject(t *testing.T) {
 			expectedErr:             kerrors.NewConflict(corev1.Resource("namespaces"), "foo", errors.New("boom")),
 			expectedValidationCalls: 1,
 		},
+		{
+			name: "validation, context timeout during retries, returns last validation error instead of timeout error",
+			ctxFunc: func() context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+				// Silence lint warning: We just want to trigger the timeout, let the cancel leak
+				_ = cancel
+				return ctx
+			},
+			reactors: []*reactor{
+				newReactor("get", "namespaces", func(called int) (runtime.Object, error) {
+					// Return a valid namespace so GET succeeds quickly
+					return &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            "foo",
+							UID:             "test-uid",
+							ResourceVersion: "123",
+						},
+					}, nil
+				}, -1),
+			},
+			objectValidator: &objectValidator{
+				objectFunc: func(ctx context.Context, obj runtime.Object) error {
+					return errors.New("admission denied: failing for test purpose")
+				},
+			},
+			expectedStatus: &metav1.Status{Status: metav1.StatusFailure},
+			// Should return the actual validation error (lastErr), not context.DeadlineExceeded
+			expectedErr: errors.New("validating project: admission denied: failing for test purpose"),
+			// Number of calls depends on how many retries fit in 50ms, so ignore call count
+			expectedValidationCalls: -1,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -471,7 +531,12 @@ func TestDeleteProject(t *testing.T) {
 				client: client.CoreV1().Namespaces(),
 			}
 
-			obj, _, err := storage.Delete(apirequest.NewContext(), "foo", validationFunc, tc.options)
+			ctx := apirequest.NewContext()
+			if tc.ctxFunc != nil {
+				ctx = tc.ctxFunc()
+			}
+
+			obj, _, err := storage.Delete(ctx, "foo", validationFunc, tc.options)
 			switch {
 			case err != nil && tc.expectedErr == nil:
 				t.Fatalf("received an unexpected error: %v", err)
@@ -485,7 +550,7 @@ func TestDeleteProject(t *testing.T) {
 				t.Fatalf("received an unexpected status. expected status: %v , received status: %v", tc.expectedStatus, obj.(*metav1.Status))
 			}
 
-			if tc.objectValidator != nil {
+			if tc.objectValidator != nil && tc.expectedValidationCalls >= 0 {
 				if tc.objectValidator.called != tc.expectedValidationCalls {
 					t.Fatalf("expected validation to be called %d times, but was called %d times", tc.expectedValidationCalls, tc.objectValidator.called)
 				}
@@ -493,7 +558,7 @@ func TestDeleteProject(t *testing.T) {
 
 			if len(tc.reactors) > 0 {
 				for _, reactor := range tc.reactors {
-					if reactor.called != reactor.expectedCalls {
+					if reactor.expectedCalls >= 0 && reactor.called != reactor.expectedCalls {
 						t.Fatalf("expected reaction for %q to be called %d times, but was called %d times", fmt.Sprintf("%s %s", reactor.verb, reactor.resource), reactor.expectedCalls, reactor.called)
 					}
 				}


### PR DESCRIPTION
Extra tests and minor QA fixes on top of #598 

@everettraven

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Project deletion with improved precondition validation to prevent unsafe deletions
  * Better error handling for concurrent modifications with automatic retry logic

* **Tests**
  * Extensive test coverage for Project creation and deletion operations including edge case scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->