### PR TITLE
deps: bump kubernetes-apiserver to pickup external claims patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -194,7 +194,8 @@ replace (
 	k8s.io/api => k8s.io/api v0.34.1
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.1
 	k8s.io/apimachinery => k8s.io/apimachinery v0.34.1
-	k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20260415154523-acdcc04896b5 // points to openshift-apiserver-4.22-kubernetes-1.34.1
+	// k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20260415154523-acdcc04896b5 // points to openshift-apiserver-4.22-kubernetes-1.34.1
+	k8s.io/apiserver => github.com/everettraven/openshift-kubernetes-apiserver v0.0.0-20260505180148-e32ae1ce5757
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.1
 	k8s.io/client-go => k8s.io/client-go v0.34.1
 	k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.1

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/everettraven/openshift-kubernetes-apiserver v0.0.0-20260505180148-e32ae1ce5757 h1:jqH06tVyyU03YYrC4oeCHSshktjiwLZ2pKaIzTONDMQ=
+github.com/everettraven/openshift-kubernetes-apiserver v0.0.0-20260505180148-e32ae1ce5757/go.mod h1:eOOc9nrVqlBI1AFCvVzsob0OxtPZUCPiUJL45JOTBG0=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f h1:Wl78ApPPB2Wvf/TIe2xdyJxTlb6obmF18d8QdkxNDu4=
 github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f/go.mod h1:OSYXu++VVOHnXeitef/D8n/6y4QV8uLHSFXX4NeXMGc=
 github.com/felixge/fgprof v0.9.3/go.mod h1:RdbpDgzqYVh/T9fPELJyV7EYJuHB55UTEULNun8eiPw=
@@ -244,8 +246,6 @@ github.com/openshift/client-go v0.0.0-20251205093018-96a6cbc1420c h1:TBE0Gl+oCo/
 github.com/openshift/client-go v0.0.0-20251205093018-96a6cbc1420c/go.mod h1:IsynOWZAfdH+BgWimcFQRtI41Id9sgdhsCEjIk8ACLw=
 github.com/openshift/docker-distribution/v3 v3.0.0-20240215131201-6b2f5d2f1f43 h1:iFiveehT5yqHvAxdTwHGZLTxyxzMqP8bLcQKz6Y7NQQ=
 github.com/openshift/docker-distribution/v3 v3.0.0-20240215131201-6b2f5d2f1f43/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
-github.com/openshift/kubernetes-apiserver v0.0.0-20260415154523-acdcc04896b5 h1:fsg0b+vZiuE5caq3QOM6bFBWfp3+1QvKixu/fzktnHI=
-github.com/openshift/kubernetes-apiserver v0.0.0-20260415154523-acdcc04896b5/go.mod h1:eOOc9nrVqlBI1AFCvVzsob0OxtPZUCPiUJL45JOTBG0=
 github.com/openshift/library-go v0.0.0-20260309173530-9ed71ac3148f h1:4nMvQlqotxtqJo4noee7Jr9AKpJZEG7fu26IJFKX5/c=
 github.com/openshift/library-go v0.0.0-20260309173530-9ed71ac3148f/go.mod h1:rYGQrSg+t1JEzeEwg6BJw3loPpXg/n3kgRygUpgxavY=
 github.com/openshift/moby-moby v0.0.0-20190308215630-da810a85109d h1:fLITXDjxMSvUDjnXs/zljIWktbST9+Om8XbrmmM7T4I=

--- a/vendor/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_patch.go
+++ b/vendor/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_patch.go
@@ -1,0 +1,8 @@
+package validation
+
+import "k8s.io/apimachinery/pkg/util/validation/field"
+
+// ValidateCertificateAuthority is an exported wrapper around validateCertificateAuthority
+func ValidateCertificateAuthority(certificateAuthority string, fldPath *field.Path) field.ErrorList {
+	return validateCertificateAuthority(certificateAuthority, fldPath)
+}

--- a/vendor/k8s.io/apiserver/pkg/authentication/cel/compile_patch.go
+++ b/vendor/k8s.io/apiserver/pkg/authentication/cel/compile_patch.go
@@ -1,0 +1,68 @@
+package cel
+
+import (
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+	"k8s.io/apimachinery/pkg/util/version"
+	apiservercel "k8s.io/apiserver/pkg/cel"
+	"k8s.io/apiserver/pkg/cel/environment"
+)
+
+type EnvironmentSet struct {
+	variableName string
+	envOptions   []cel.EnvOption
+	declTypes    []*apiservercel.DeclType
+}
+
+func (es *EnvironmentSet) Build(baseEnv *environment.EnvSet) (*environment.EnvSet, error) {
+	return baseEnv.Extend(environment.VersionedOptions{
+		IntroducedVersion: version.MajorMinor(1, 0),
+		EnvOptions:        es.envOptions,
+		DeclTypes:         es.declTypes,
+	})
+}
+
+// NewEnvironmentSet returns a *EnvironmentSet that is used for configuring an ExtendableCompiler
+// with a new CEL environment variable. The variable name parameter is an arbitrary string
+// representing the new environment variable. It must not be empty.
+func NewEnvironmentSet(variableName string, options []cel.EnvOption, declTypes []*apiservercel.DeclType) *EnvironmentSet {
+	if len(variableName) == 0 {
+		panic("variable name must not be an empty string")
+	}
+
+	return &EnvironmentSet{
+		variableName: variableName,
+		envOptions:   options,
+		declTypes:    declTypes,
+	}
+}
+
+// ExtendableCompiler is an extension of the baseline compiler
+// that allows for extending the capabilities of the baseline compiler.
+type ExtendableCompiler struct {
+	*compiler
+}
+
+func (ec *ExtendableCompiler) Compile(accessor ExpressionAccessor, variableName string) (CompilationResult, error) {
+	return ec.compiler.compile(accessor, variableName)
+}
+
+func NewExtendableCompiler(baseEnv *environment.EnvSet, additionalEnvSets ...*EnvironmentSet) *ExtendableCompiler {
+	compiler := &compiler{
+		varEnvs: mustBuildEnvs(baseEnv),
+	}
+
+	for _, envSet := range additionalEnvSets {
+		builtEnvSet, err := envSet.Build(baseEnv)
+		if err != nil {
+			panic(fmt.Sprintf("building environment set for variable %q: %v", envSet.variableName, err))
+		}
+
+		compiler.varEnvs[envSet.variableName] = builtEnvSet
+	}
+
+	return &ExtendableCompiler{
+		compiler: compiler,
+	}
+}

--- a/vendor/k8s.io/apiserver/pkg/authentication/cel/mapper_patch.go
+++ b/vendor/k8s.io/apiserver/pkg/authentication/cel/mapper_patch.go
@@ -1,0 +1,36 @@
+package cel
+
+import (
+	"context"
+
+	"github.com/google/cel-go/common/types/traits"
+)
+
+type Mapper struct {
+	*mapper
+}
+
+func NewMapper(compilationResults []CompilationResult) *Mapper {
+	return &Mapper{
+		mapper: &mapper{
+			compilationResults: compilationResults,
+		},
+	}
+}
+
+func (m *Mapper) Eval(ctx context.Context, input VarNameActivation) ([]EvaluationResult, error) {
+	return m.mapper.eval(ctx, input.varNameActivation)
+}
+
+type VarNameActivation struct {
+	*varNameActivation
+}
+
+func NewVarNameActivation(name string, value traits.Mapper) VarNameActivation {
+	return VarNameActivation{
+		varNameActivation: &varNameActivation{
+			name: name,
+			value: value,
+		},
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1360,7 +1360,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/apiserver v0.34.1 => github.com/openshift/kubernetes-apiserver v0.0.0-20260415154523-acdcc04896b5
+# k8s.io/apiserver v0.34.1 => github.com/everettraven/openshift-kubernetes-apiserver v0.0.0-20260505180148-e32ae1ce5757
 ## explicit; go 1.24.0
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/configuration
@@ -2413,7 +2413,7 @@ sigs.k8s.io/yaml/kyaml
 # k8s.io/api => k8s.io/api v0.34.1
 # k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.1
 # k8s.io/apimachinery => k8s.io/apimachinery v0.34.1
-# k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20260415154523-acdcc04896b5
+# k8s.io/apiserver => github.com/everettraven/openshift-kubernetes-apiserver v0.0.0-20260505180148-e32ae1ce5757
 # k8s.io/cli-runtime => k8s.io/cli-runtime v0.34.1
 # k8s.io/client-go => k8s.io/client-go v0.34.1
 # k8s.io/cloud-provider => k8s.io/cloud-provider v0.34.1


### PR DESCRIPTION
DO NOT MERGE.

This is a proof PR for https://github.com/openshift/kubernetes-apiserver/pull/87

/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the internal Kubernetes API server dependency to a newer forked version and adjusted the accompanying reference comment. No user-facing changes or API alterations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->