### PR TITLE
OCPBUGS-78480: address review feedback on project watcher

### DIFF
--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -122,7 +122,7 @@ func (s *REST) Watch(ctx context.Context, options *metainternal.ListOptions) (wa
 		if options.ResourceVersion == "0" {
 			includeAllExistingProjects = true
 		}
-		if options.SendInitialEvents != nil && *options.SendInitialEvents {
+		if options.SendInitialEvents != nil && *options.SendInitialEvents && options.AllowWatchBookmarks {
 			sendBookmark = true
 		}
 	}

--- a/pkg/project/auth/watch.go
+++ b/pkg/project/auth/watch.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"errors"
+	"strconv"
 	"sync"
 
 	"k8s.io/klog/v2"
@@ -65,7 +66,8 @@ type userProjectWatcher struct {
 	// knownProjects maps name to resourceVersion
 	knownProjects map[string]string
 
-	sendBookmark bool
+	sendBookmark            bool
+	bookmarkResourceVersion string
 }
 
 var (
@@ -75,10 +77,16 @@ var (
 )
 
 func NewUserProjectWatcher(user user.Info, visibleNamespaces sets.String, projectCache *projectcache.ProjectCache, authCache WatchableCache, includeAllExistingProjects bool, predicate kstorage.SelectionPredicate, sendBookmark bool) *userProjectWatcher {
+	// TODO: authCache.List materializes all visible namespaces per watcher, increasing memory
+	// proportional to concurrent watchers. Consider streaming events from WatchableCache instead.
 	namespaces, _ := authCache.List(user, labels.Everything())
 	knownProjects := map[string]string{}
+	var maxRV int
 	for _, namespace := range namespaces.Items {
 		knownProjects[namespace.Name] = namespace.ResourceVersion
+		if n, err := strconv.Atoi(namespace.ResourceVersion); err == nil && n > maxRV {
+			maxRV = n
+		}
 	}
 
 	// this is optional.  If they don't request it, don't include it.
@@ -101,7 +109,8 @@ func NewUserProjectWatcher(user user.Info, visibleNamespaces sets.String, projec
 		initialProjects: initialProjects,
 		knownProjects:   knownProjects,
 
-		sendBookmark: sendBookmark,
+		sendBookmark:            sendBookmark,
+		bookmarkResourceVersion: strconv.Itoa(maxRV),
 	}
 	w.emit = func(e watch.Event) {
 		if e.Type != watch.Bookmark {
@@ -199,6 +208,10 @@ func (w *userProjectWatcher) GroupMembershipChanged(namespaceName string, users,
 // acknowledges that project visibility depends on both namespace objects and RBAC state. Since
 // RBAC changes don't update namespace ResourceVersions, permission-filtered views cannot provide
 // the same consistency guarantees (resourceVersionMatch=NotOlderThan) as direct object watches.
+//
+// Limitation: Unlike upstream's cacher which streams initial events from a shared watch cache,
+// this implementation materializes all visible namespaces per watcher via authCache.List,
+// so we do not fully realize the memory savings that KEP-3157 WatchList is designed to provide.
 func (w *userProjectWatcher) Watch() {
 	defer close(w.outgoing)
 	defer func() {
@@ -227,12 +240,15 @@ func (w *userProjectWatcher) Watch() {
 		})
 	}
 
+	// When sendBookmark is true but initialProjects is empty (RV != "0"), only
+	// the bookmark is emitted with no preceding Added events. See design comment above.
 	if w.sendBookmark {
 		w.emit(watch.Event{
 			Type: watch.Bookmark,
 			Object: &projectapi.Project{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{metav1.InitialEventsAnnotationKey: "true"},
+					ResourceVersion: w.bookmarkResourceVersion,
+					Annotations:     map[string]string{metav1.InitialEventsAnnotationKey: "true"},
 				},
 			},
 		})

--- a/pkg/project/auth/watch_test.go
+++ b/pkg/project/auth/watch_test.go
@@ -159,10 +159,10 @@ func TestAddModifyDeleteEventsByUser(t *testing.T) {
 }
 
 func TestProjectSelectionPredicate(t *testing.T) {
-	field := fields.ParseSelectorOrDie("metadata.name=ns-03")
-	m := projectutil.MatchProject(labels.Everything(), field)
+	fieldSelector := fields.ParseSelectorOrDie("metadata.name=ns-03")
+	predicate := projectutil.MatchProject(labels.Everything(), fieldSelector)
 
-	watcher, _, stopCh := newTestWatcher("bob", nil, m, false, newNamespaces("ns-01", "ns-02", "ns-03")...)
+	watcher, _, stopCh := newTestWatcher("bob", nil, predicate, false, newNamespaces("ns-01", "ns-02", "ns-03")...)
 	defer close(stopCh)
 
 	if watcher.emit == nil {
@@ -304,7 +304,7 @@ func newBookmarkTestWatcher(username string, includeAllExistingProjects bool, na
 	fakeAuthCache := &fakeAuthCache{namespaces: namespaces}
 	stopCh := make(chan struct{})
 	go projectCache.Run(stopCh)
-	w := NewUserProjectWatcher(
+	watcher := NewUserProjectWatcher(
 		&user.DefaultInfo{Name: username},
 		sets.NewString("*"),
 		projectCache,
@@ -313,7 +313,7 @@ func newBookmarkTestWatcher(username string, includeAllExistingProjects bool, na
 		matchAllPredicate(),
 		true,
 	)
-	return w, stopCh
+	return watcher, stopCh
 }
 
 func TestSendInitialEventsBookmark(t *testing.T) {
@@ -335,7 +335,7 @@ func TestSendInitialEventsBookmark(t *testing.T) {
 			}
 		}
 
-		// expect bookmark with annotation
+		// expect bookmark with annotation and ResourceVersion
 		select {
 		case event := <-watcher.ResultChan():
 			if event.Type != watch.Bookmark {
@@ -344,6 +344,9 @@ func TestSendInitialEventsBookmark(t *testing.T) {
 			project := event.Object.(*projectapi.Project)
 			if project.Annotations[metav1.InitialEventsAnnotationKey] != "true" {
 				t.Errorf("expected initial-events-end annotation")
+			}
+			if project.ResourceVersion != "11" {
+				t.Errorf("expected ResourceVersion 11 (max across namespaces), got %v", project.ResourceVersion)
 			}
 		case <-time.After(3 * time.Second):
 			t.Fatalf("timeout waiting for bookmark")
@@ -355,8 +358,8 @@ func TestSendInitialEventsBookmark(t *testing.T) {
 		// (e.g. metadata.name=<project>) would reject the bookmark's empty Name.
 		// This is critical for oc delete --wait which watches a specific project
 		// and needs the bookmark to complete the initial events stream.
-		field := fields.ParseSelectorOrDie("metadata.name=ns-01")
-		m := projectutil.MatchProject(labels.Everything(), field)
+		fieldSelector := fields.ParseSelectorOrDie("metadata.name=ns-01")
+		predicate := projectutil.MatchProject(labels.Everything(), fieldSelector)
 
 		objects := []runtime.Object{}
 		namespaces := newNamespacesWithRV("ns-01", "ns-02")
@@ -375,25 +378,28 @@ func TestSendInitialEventsBookmark(t *testing.T) {
 		defer close(stopCh)
 		go projectCache.Run(stopCh)
 
-		w := NewUserProjectWatcher(
+		watcher := NewUserProjectWatcher(
 			&user.DefaultInfo{Name: "bob"},
 			sets.NewString("*"),
 			projectCache,
 			fakeAuthCache,
 			false,
-			m,
+			predicate,
 			true,
 		)
-		go w.Watch()
+		go watcher.Watch()
 
 		select {
-		case event := <-w.ResultChan():
+		case event := <-watcher.ResultChan():
 			if event.Type != watch.Bookmark {
 				t.Errorf("expected Bookmark, got %v", event.Type)
 			}
 			project := event.Object.(*projectapi.Project)
 			if project.Annotations[metav1.InitialEventsAnnotationKey] != "true" {
 				t.Errorf("expected initial-events-end annotation")
+			}
+			if project.ResourceVersion == "0" {
+				t.Errorf("expected non-zero ResourceVersion on bookmark, got %v", project.ResourceVersion)
 			}
 		case <-time.After(3 * time.Second):
 			t.Fatalf("timeout waiting for bookmark — predicate likely filtered it out")
@@ -415,6 +421,9 @@ func TestSendInitialEventsBookmark(t *testing.T) {
 			project := event.Object.(*projectapi.Project)
 			if project.Annotations[metav1.InitialEventsAnnotationKey] != "true" {
 				t.Errorf("expected initial-events-end annotation")
+			}
+			if project.ResourceVersion == "0" {
+				t.Errorf("expected non-zero ResourceVersion on bookmark, got %v", project.ResourceVersion)
 			}
 		case <-time.After(3 * time.Second):
 			t.Fatalf("timeout waiting for bookmark")


### PR DESCRIPTION
## Summary
- Add `AllowWatchBookmarks` check to `sendBookmark` condition in proxy.go to match upstream Kubernetes pattern
- Restore `ResourceVersion` on bookmark event (max RV across namespace items) so reflectors can resume watches
- Rename non-obvious test variables (`m`→`predicate`, `field`→`fieldSelector`, `w`→`watcher`)
- Add TODO documenting WatchList memory limitation and inline comments clarifying bookmark-only behavior

## Context
Addresses post-merge review comments from @atiratree on PR #661.

## Test plan
- [x] All existing tests pass (`go test ./pkg/project/auth/... -v`)
- [x] Bookmark ResourceVersion assertion added to `TestSendInitialEventsBookmark/with_rv=0`
- [x] `proxy.go` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Initial watch bookmarks are now sent only when bookmark delivery is explicitly enabled, not just when initial events are requested.
  * Initial project watch bookmarks now include the latest observed resource version, improving consistency and correctness of bookmark events.
* **Tests**
  * Updated and strengthened watch/bookmark assertions to verify resource-version behavior and maintain existing predicate coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->