### PR TITLE
OCPBUGS-85429: hack/update-openapi-spec: prefer REGISTRY_AUTH_FILE over cluster profile pull secret

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -153,12 +153,12 @@ echo "Using OpenShift release: ${OPENSHIFT_RELEASE}"
 
 # Set up registry authentication if available
 REGISTRY_AUTH_OPTS=""
-if [[ -n "${CLUSTER_PROFILE_DIR:-}" && -f "${CLUSTER_PROFILE_DIR}/pull-secret" ]]; then
-  echo "Using pull secret from ${CLUSTER_PROFILE_DIR}/pull-secret"
-  REGISTRY_AUTH_OPTS="--registry-config=${CLUSTER_PROFILE_DIR}/pull-secret"
-elif [[ -n "${REGISTRY_AUTH_FILE:-}" && -f "${REGISTRY_AUTH_FILE}" ]]; then
+if [[ -n "${REGISTRY_AUTH_FILE:-}" && -f "${REGISTRY_AUTH_FILE}" ]]; then
   echo "Using pull secret from ${REGISTRY_AUTH_FILE}"
   REGISTRY_AUTH_OPTS="--registry-config=${REGISTRY_AUTH_FILE}"
+elif [[ -n "${CLUSTER_PROFILE_DIR:-}" && -f "${CLUSTER_PROFILE_DIR}/pull-secret" ]]; then
+  echo "Using pull secret from ${CLUSTER_PROFILE_DIR}/pull-secret"
+  REGISTRY_AUTH_OPTS="--registry-config=${CLUSTER_PROFILE_DIR}/pull-secret"
 else
   echo "WARNING: No pull secret found. Proceeding without authentication."
   echo "This may fail if accessing private registries."


### PR DESCRIPTION
Check `REGISTRY_AUTH_FILE` before `CLUSTER_PROFILE_DIR/pull-secret` so the CI job config can provide credentials for registries not covered by the cluster profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registry operations now prioritize the authentication file specified by `REGISTRY_AUTH_FILE`.
  * Falls back to the cluster profile pull secret when no explicit authentication file is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->