### PR TITLE
Revert "OCPBUGS-85429: hack/update-openapi-spec: prefer REGISTRY_AUTH_FILE over cluster profile pull secret"

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -153,12 +153,12 @@ echo "Using OpenShift release: ${OPENSHIFT_RELEASE}"
 
 # Set up registry authentication if available
 REGISTRY_AUTH_OPTS=""
-if [[ -n "${REGISTRY_AUTH_FILE:-}" && -f "${REGISTRY_AUTH_FILE}" ]]; then
-  echo "Using pull secret from ${REGISTRY_AUTH_FILE}"
-  REGISTRY_AUTH_OPTS="--registry-config=${REGISTRY_AUTH_FILE}"
-elif [[ -n "${CLUSTER_PROFILE_DIR:-}" && -f "${CLUSTER_PROFILE_DIR}/pull-secret" ]]; then
+if [[ -n "${CLUSTER_PROFILE_DIR:-}" && -f "${CLUSTER_PROFILE_DIR}/pull-secret" ]]; then
   echo "Using pull secret from ${CLUSTER_PROFILE_DIR}/pull-secret"
   REGISTRY_AUTH_OPTS="--registry-config=${CLUSTER_PROFILE_DIR}/pull-secret"
+elif [[ -n "${REGISTRY_AUTH_FILE:-}" && -f "${REGISTRY_AUTH_FILE}" ]]; then
+  echo "Using pull secret from ${REGISTRY_AUTH_FILE}"
+  REGISTRY_AUTH_OPTS="--registry-config=${REGISTRY_AUTH_FILE}"
 else
   echo "WARNING: No pull secret found. Proceeding without authentication."
   echo "This may fail if accessing private registries."


### PR DESCRIPTION
Reverts openshift/openshift-apiserver#669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registry authentication now prioritizes the cluster profile pull secret.
  * Falls back to `REGISTRY_AUTH_FILE` only when the cluster profile secret is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->