### PR TITLE
OCPBUGS-94042: Return proper 404 when deleting a non-existent project

### DIFF
--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -268,6 +268,9 @@ func (s *REST) Delete(ctx context.Context, name string, objectFunc rest.Validate
 	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
 		project, err := s.getProjectForDeletion(ctx, name)
 		if err != nil {
+			if kerrors.IsNotFound(err) {
+				return false, err
+			}
 			lastErr = fmt.Errorf("getting project for deletion: %w", err)
 			return false, nil
 		}
@@ -322,6 +325,9 @@ func (s *REST) getProjectForDeletion(ctx context.Context, name string) (*project
 
 	obj, err := s.Get(ctx, name, &getOpts)
 	if err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("unable to get project: %w", err)
 	}
 

--- a/pkg/project/apiserver/registry/project/proxy/proxy_test.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy_test.go
@@ -215,6 +215,7 @@ func TestDeleteProject(t *testing.T) {
 		options         *metav1.DeleteOptions
 		expectedStatus  *metav1.Status
 		expectedErr     error
+		expectedErrFunc func(error) bool
 		// Use -1 to ignore
 		expectedValidationCalls int
 	}
@@ -244,6 +245,27 @@ func TestDeleteProject(t *testing.T) {
 			expectedStatus:          &metav1.Status{Status: metav1.StatusFailure},
 			expectedValidationCalls: 10,
 			expectedErr:             errors.New("validating project: boom"),
+		},
+		{
+			name: "has validation, getting project returns not found, no retry, returns not found error",
+			reactors: []*reactor{
+				newReactor(
+					"get",
+					"namespaces",
+					func(called int) (runtime.Object, error) {
+						return nil, kerrors.NewNotFound(corev1.Resource("namespaces"), "foo")
+					},
+					1,
+				),
+			},
+			objectValidator: &objectValidator{
+				objectFunc: func(ctx context.Context, obj runtime.Object) error {
+					return nil
+				},
+			},
+			expectedStatus:          &metav1.Status{Status: metav1.StatusFailure},
+			expectedErrFunc:         kerrors.IsNotFound,
+			expectedValidationCalls: 0,
 		},
 		{
 			name: "has validation, getting project perma-fails with non-terminal error, no options, validation never called, request fails",
@@ -548,13 +570,22 @@ func TestDeleteProject(t *testing.T) {
 			}
 
 			obj, _, err := storage.Delete(ctx, "foo", validationFunc, tc.options)
-			switch {
-			case err != nil && tc.expectedErr == nil:
-				t.Fatalf("received an unexpected error: %v", err)
-			case err == nil && tc.expectedErr != nil:
-				t.Fatalf("expected an error but did not receive one. expected error: %v", tc.expectedErr)
-			case err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error():
-				t.Fatalf("received error does not match expected error. expected error: %v , received error: %v", tc.expectedErr, err)
+			if tc.expectedErrFunc != nil {
+				if err == nil {
+					t.Fatalf("expected an error but did not receive one")
+				}
+				if !tc.expectedErrFunc(err) {
+					t.Fatalf("error did not pass expected classification check: %v", err)
+				}
+			} else {
+				switch {
+				case err != nil && tc.expectedErr == nil:
+					t.Fatalf("received an unexpected error: %v", err)
+				case err == nil && tc.expectedErr != nil:
+					t.Fatalf("expected an error but did not receive one. expected error: %v", tc.expectedErr)
+				case err != nil && tc.expectedErr != nil && err.Error() != tc.expectedErr.Error():
+					t.Fatalf("received error does not match expected error. expected error: %v , received error: %v", tc.expectedErr, err)
+				}
 			}
 
 			if tc.expectedStatus.Status != obj.(*metav1.Status).Status {


### PR DESCRIPTION
The project delete handler wraps NotFound errors from the underlying namespace GET with fmt.Errorf, turning the *StatusError into a *fmt.wrapError. The apiserver framework's ErrorToAPIStatus uses a direct type assertion (not errors.As) to extract the status, so the wrapped error falls through to the default case and produces HTTP 500 with no Reason. This makes --ignore-not-found ineffective because errors.IsNotFound checks for Reason=NotFound or Code=404.

Return NotFound errors unwrapped from getProjectForDeletion and treat them as terminal in the retry loop so the original StatusError reaches ErrorToAPIStatus intact, producing a proper 404 response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project deletion now stops immediately when the requested project cannot be found, avoiding unnecessary retry attempts.
  * Other project retrieval errors continue to follow the existing retry behavior.
  * Error handling now more clearly distinguishes missing projects from temporary or unexpected retrieval failures, providing more predictable deletion outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->