### PR TITLE
WIP: OCPBUGS-105786: Include all projects when sending initial events, not just the bookmark alone

### DIFF
--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -119,10 +119,11 @@ func (s *REST) Watch(ctx context.Context, options *metainternal.ListOptions) (wa
 	// k8s.io/initial-events-end annotation after initial events (if any).
 	includeAllExistingProjects, sendBookmark := false, false
 	if options != nil {
-		if options.ResourceVersion == "0" {
+		wantInitialEvents := options.SendInitialEvents != nil && *options.SendInitialEvents && options.AllowWatchBookmarks
+		if options.ResourceVersion == "0" || wantInitialEvents {
 			includeAllExistingProjects = true
 		}
-		if options.SendInitialEvents != nil && *options.SendInitialEvents && options.AllowWatchBookmarks {
+		if wantInitialEvents {
 			sendBookmark = true
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project watch behavior for initial-event requests.
  * Ensured existing projects are delivered only when bookmark support is enabled.
  * Preserved the ability to request all existing projects using resource version `0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->