### PR TITLE
Reject WatchList requests for Project resources

### DIFF
--- a/pkg/project/apiserver/registry/project/proxy/proxy.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy.go
@@ -109,6 +109,15 @@ func (s *REST) Watch(ctx context.Context, options *metainternal.ListOptions) (wa
 	if ctx == nil {
 		return nil, fmt.Errorf("Context is nil")
 	}
+
+	// Reject WatchList (sendInitialEvents) requests. The Project resource is a
+	// virtual/proxy type backed by filtered Namespaces and cannot properly serve
+	// the WatchList protocol. Returning an error here causes client-go's
+	// reflector to fall back to the standard LIST+WATCH semantics.
+	if options != nil && options.SendInitialEvents != nil && *options.SendInitialEvents {
+		return nil, kerrors.NewMethodNotSupported(project.Resource("project"), "watch-list")
+	}
+
 	userInfo, exists := apirequest.UserFrom(ctx)
 	if !exists {
 		return nil, fmt.Errorf("no user")

--- a/pkg/project/apiserver/registry/project/proxy/proxy_test.go
+++ b/pkg/project/apiserver/registry/project/proxy/proxy_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/api/project"
 	oapi "github.com/openshift/openshift-apiserver/pkg/api"
 	projectapi "github.com/openshift/openshift-apiserver/pkg/project/apis/project"
+	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 )
 
 // mockLister returns the namespaces in the list
@@ -65,6 +66,24 @@ func TestListProjects(t *testing.T) {
 	responseProject := projects.Items[0]
 	if e, r := responseProject.Name, "foo"; e != r {
 		t.Errorf("%#v != %#v.", e, r)
+	}
+}
+
+func TestWatchRejectsSendInitialEvents(t *testing.T) {
+	storage := &REST{}
+	userInfo := &user.DefaultInfo{
+		Name: "test-user",
+	}
+	ctx := apirequest.WithUser(apirequest.NewContext(), userInfo)
+
+	_, err := storage.Watch(ctx, &metainternal.ListOptions{
+		SendInitialEvents: ptr.To(true),
+	})
+	if err == nil {
+		t.Fatal("expected an error but got nil")
+	}
+	if !kerrors.IsMethodNotSupported(err) {
+		t.Errorf("expected MethodNotSupported error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Reject WatchList requests for Project resources because the Project watch handler does not support the sendInitialEvents protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project watch requests using initial event delivery are now rejected with a clear “method not supported” error.
  * Existing watch behavior remains unchanged for supported request options.

* **Tests**
  * Added coverage to verify unsupported initial-event watch requests are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->